### PR TITLE
Add CS 523 contributors to DESCRIPTION

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,11 +1,15 @@
 Package: imuGAP
 Title: Estimate Measles Vaccine Coverage
 Version: 0.0.0.9000
-Authors@R: 
+Authors@R:
     c(person("Carl", "Pearson", email = "carl.ab.pearson@gmail.com", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0003-0701-7860")),
       person("Claire Perrin", "Smith", role = "aut",
-           comment = c(ORCID = "0000-0003-1069-9460")))
+           comment = c(ORCID = "0000-0003-1069-9460")),
+      person("Kelly", "Zhen", email = "zhen717605@gmail.com", role = "ctb"),
+      person("Weston", "Voglesonger", email = "westonvogle@gmail.com", role = "ctb"),
+      person("Joshua", "Chen", email = "joshuazchen1@gmail.com", role = "ctb"),
+      person("Minjae", "Kung", email = "minjaekung@gmail.com", role = "ctb"))
 Description: What the package does (one paragraph).
 License: MIT + file LICENSE
 Encoding: UTF-8


### PR DESCRIPTION
## Summary
Adds the CS 523 contributors to `Authors@R` in `DESCRIPTION` with `role = "ctb"`:

- Kelly Zhen — zhen717605@gmail.com
- Weston Voglesonger — westonvogle@gmail.com
- Joshua Chen — joshuazchen1@gmail.com
- Minjae Kung — minjaekung@gmail.com

Existing entries (Carl Pearson, Claire Perrin Smith) are unchanged.

Closes #22.

## Test plan
- [ ] `R CMD check` passes (DESCRIPTION-only change).