### PR TITLE
Expand function test coverage to 95%

### DIFF
--- a/NAMESPACE
+++ b/NAMESPACE
@@ -3,6 +3,7 @@
 export(canonicalize_locations)
 export(canonicalize_observations)
 export(canonicalize_populations)
+export(extract_imugap)
 export(imuGAP)
 export(imugap_options)
 export(install_cli)

--- a/R/imuGAP.R
+++ b/R/imuGAP.R
@@ -498,6 +498,7 @@ imuGAP <- function( # nolint
 #'
 #' @return a list, as returned by `rstan::extract()`
 #'
+#' @export
 extract_imugap <- function(fit, pars = c("logit_phi_state"), ...) {
   return(rstan::extract(fit, pars = pars, ...))
 }

--- a/tests/testthat/helper-fixtures.R
+++ b/tests/testthat/helper-fixtures.R
@@ -1,9 +1,14 @@
-library(data.table)
-
 make_test_locs <- function() {
   data.frame(
     loc_id = c("state", "cnty", "schl"),
     parent_id = c(NA, "state", "cnty")
+  )
+}
+
+make_test_locs_implicit_root <- function() {
+  data.frame(
+    loc_id = c("a", "b", "c"),
+    parent_id = c("root", "a", "a")
   )
 }
 
@@ -16,7 +21,7 @@ make_test_obs <- function() {
 }
 
 make_test_pops <- function() {
-  data.table(
+  data.frame(
     obs_id = c("o1", "o2"),
     loc_id = c("schl", "schl"),
     cohort = c(1L, 1L),

--- a/tests/testthat/helper-fixtures.R
+++ b/tests/testthat/helper-fixtures.R
@@ -1,0 +1,27 @@
+library(data.table)
+
+make_test_locs <- function() {
+  data.frame(
+    loc_id = c("state", "cnty", "schl"),
+    parent_id = c(NA, "state", "cnty")
+  )
+}
+
+make_test_obs <- function() {
+  data.frame(
+    obs_id = c("o1", "o2"),
+    positive = c(5L, 10L),
+    sample_n = c(10L, 20L)
+  )
+}
+
+make_test_pops <- function() {
+  data.table(
+    obs_id = c("o1", "o2"),
+    loc_id = c("schl", "schl"),
+    cohort = c(1L, 1L),
+    age = c(2L, 2L),
+    dose = c(1L, 2L),
+    weight = c(1.0, 1.0)
+  )
+}

--- a/tests/testthat/test-canonicalize_locations.R
+++ b/tests/testthat/test-canonicalize_locations.R
@@ -81,16 +81,14 @@ test_that("yields data.table with ordered layer, parent_id, and id columns", {
 })
 
 test_that("infers implicit root when no row has parent_id == NA", {
-  # Root is implicit: parent_id "root" doesn't appear as a loc_id.
-  # The function should add a row for the implicit root.
   ref <- data.frame(
     loc_id = c("a", "b", "c"),
     parent_id = c("root", "a", "a")
   )
   res <- canonicalize_locations(ref)
-  expect_true("root" %in% res$loc_id)
-  # The implicit root is at layer 1
-  expect_equal(res[res$loc_id == "root", "layer"][[1]], 1L)
+  root_rows <- res[res$layer == 1L, ]
+  expect_equal(nrow(root_rows), 1L)
+  expect_equal(root_rows$loc_id, "root")
 })
 
 test_that("canonical input short-circuits and returns unchanged", {

--- a/tests/testthat/test-canonicalize_locations.R
+++ b/tests/testthat/test-canonicalize_locations.R
@@ -81,11 +81,7 @@ test_that("yields data.table with ordered layer, parent_id, and id columns", {
 })
 
 test_that("infers implicit root when no row has parent_id == NA", {
-  ref <- data.frame(
-    loc_id = c("a", "b", "c"),
-    parent_id = c("root", "a", "a")
-  )
-  res <- canonicalize_locations(ref)
+  res <- canonicalize_locations(make_test_locs_implicit_root())
   root_rows <- res[res$layer == 1L, ]
   expect_equal(nrow(root_rows), 1L)
   expect_equal(root_rows$loc_id, "root")

--- a/tests/testthat/test-canonicalize_locations.R
+++ b/tests/testthat/test-canonicalize_locations.R
@@ -88,11 +88,7 @@ test_that("infers implicit root when no row has parent_id == NA", {
 })
 
 test_that("canonical input short-circuits and returns unchanged", {
-  ref <- data.frame(
-    loc_id = c("a", "b", "c"),
-    parent_id = c(NA, "a", "a")
-  )
-  canon <- canonicalize_locations(ref)
+  canon <- canonicalize_locations(make_test_locs())
   again <- canonicalize_locations(canon)
   expect_identical(canon, again)
 })

--- a/tests/testthat/test-canonicalize_locations.R
+++ b/tests/testthat/test-canonicalize_locations.R
@@ -79,3 +79,26 @@ test_that("yields data.table with ordered layer, parent_id, and id columns", {
   expect_equal(locs$loc_cp_id, sort(locs$loc_cp_id, na.last = FALSE))
 
 })
+
+test_that("infers implicit root when no row has parent_id == NA", {
+  # Root is implicit: parent_id "root" doesn't appear as a loc_id.
+  # The function should add a row for the implicit root.
+  ref <- data.frame(
+    loc_id = c("a", "b", "c"),
+    parent_id = c("root", "a", "a")
+  )
+  res <- canonicalize_locations(ref)
+  expect_true("root" %in% res$loc_id)
+  # The implicit root is at layer 1
+  expect_equal(res[res$loc_id == "root", "layer"][[1]], 1L)
+})
+
+test_that("canonical input short-circuits and returns unchanged", {
+  ref <- data.frame(
+    loc_id = c("a", "b", "c"),
+    parent_id = c(NA, "a", "a")
+  )
+  canon <- canonicalize_locations(ref)
+  again <- canonicalize_locations(canon)
+  expect_identical(canon, again)
+})

--- a/tests/testthat/test-canonicalize_observations.R
+++ b/tests/testthat/test-canonicalize_observations.R
@@ -71,3 +71,52 @@ test_that("can ensure scientific validity", {
   expect_error(canonicalize_observations(obs_pos_samp_inconsistent), "sample_n")
 
 })
+
+test_that("errors when obs_id contains NA", {
+  obs <- data.frame(
+    obs_id = c("a", NA, "c"),
+    positive = c(5, 10, 15),
+    sample_n = c(10, 20, 30)
+  )
+  expect_error(canonicalize_observations(obs), "obs_id.*NA")
+})
+
+test_that("errors when obs_id has duplicates", {
+  obs <- data.frame(
+    obs_id = c("a", "b", "a"),
+    positive = c(5, 10, 15),
+    sample_n = c(10, 20, 30)
+  )
+  expect_error(canonicalize_observations(obs), "unique")
+})
+
+test_that("errors when censored column is not numeric", {
+  obs <- data.frame(
+    obs_id = c("a", "b", "c"),
+    positive = c(5, 10, 15),
+    sample_n = c(10, 20, 30),
+    censored = c("no", "yes", "no")
+  )
+  expect_error(canonicalize_observations(obs), "censored.*numeric")
+})
+
+test_that("errors when censored column contains values other than NA or 1", {
+  obs <- data.frame(
+    obs_id = c("a", "b", "c"),
+    positive = c(5, 10, 15),
+    sample_n = c(10, 20, 30),
+    censored = c(NA, 0, 1)  # 0 is not allowed (reserved for left-censoring)
+  )
+  expect_error(canonicalize_observations(obs), "censored")
+})
+
+test_that("canonical input short-circuits and returns unchanged", {
+  obs <- data.frame(
+    obs_id = c("a", "b", "c"),
+    positive = c(5, 10, 15),
+    sample_n = c(10, 20, 30)
+  )
+  canon <- canonicalize_observations(obs)
+  again <- canonicalize_observations(canon)
+  expect_identical(canon, again)
+})

--- a/tests/testthat/test-canonicalize_populations.R
+++ b/tests/testthat/test-canonicalize_populations.R
@@ -31,7 +31,7 @@ test_that("canonicalize_populations assigns range_start by obs_c_id", {
   pops <- data.table::data.table(
     obs_id = c("o1", "o1", "o2", "o2"),
     loc_id = c("schl", "schl", "schl", "schl"),
-    cohort = c(1L, 1L, 1L, 1L),
+    cohort = c(1L, 1L, 2L, 2L),
     age = c(2L, 2L, 2L, 2L),
     dose = c(1L, 2L, 1L, 2L),
     weight = c(0.5, 0.5, 0.6, 0.4)
@@ -111,7 +111,7 @@ test_that("canonicalize_populations errors on cohort > max_cohort", {
 
 test_that("canonicalize_populations errors on age > max_age", {
   bad <- make_test_pops()
-  bad$age <- c(2L, 99L)
+  bad[2, "age"] <- 99L
   expect_error(
     canonicalize_populations(
       bad, make_test_obs(), make_test_locs(),

--- a/tests/testthat/test-canonicalize_populations.R
+++ b/tests/testthat/test-canonicalize_populations.R
@@ -1,48 +1,9 @@
-# Tests for canonicalize_populations()
-#
-# canonicalize_populations validates the (obs_id, loc_id, cohort, age, dose,
-# weight) mapping table that ties observations back to a (location, cohort,
-# age, dose) tuple. Tests cover the happy path, every validation branch, and
-# the canonical-passthrough.
 
-library(data.table)
 
-# --- helpers -----------------------------------------------------------------
-
-# Minimal valid trio for population tests. Two observations, three locations
-# (state -> county -> school), one cohort/age/dose row per observation so
-# weights sum to 1 trivially.
-make_locs <- function() {
-  data.frame(
-    loc_id = c("state", "cnty", "schl"),
-    parent_id = c(NA, "state", "cnty")
-  )
-}
-
-make_obs <- function() {
-  data.frame(
-    obs_id = c("o1", "o2"),
-    positive = c(5L, 10L),
-    sample_n = c(10L, 20L)
-  )
-}
-
-make_pops <- function() {
-  data.table::data.table(
-    obs_id = c("o1", "o2"),
-    loc_id = c("schl", "schl"),
-    cohort = c(1L, 1L),
-    age = c(2L, 2L),
-    dose = c(1L, 2L),
-    weight = c(1.0, 1.0)
-  )
-}
-
-# --- happy path --------------------------------------------------------------
 
 test_that("canonicalize_populations succeeds on valid input", {
   res <- canonicalize_populations(
-    make_pops(), make_obs(), make_locs(),
+    make_test_pops(), make_test_obs(), make_test_locs(),
     max_cohort = 5L, max_age = 10L
   )
   expect_s3_class(res, "data.table")
@@ -54,12 +15,12 @@ test_that("canonicalize_populations succeeds on valid input", {
 
 test_that("canonicalize_populations short-circuits on canonical input", {
   res1 <- canonicalize_populations(
-    make_pops(), make_obs(), make_locs(),
+    make_test_pops(), make_test_obs(), make_test_locs(),
     max_cohort = 5L, max_age = 10L
   )
   # second pass should pass through unchanged (no validation, no error)
   res2 <- canonicalize_populations(
-    res1, make_obs(), make_locs(),
+    res1, make_test_obs(), make_test_locs(),
     max_cohort = 5L, max_age = 10L
   )
   expect_identical(res1, res2)
@@ -76,7 +37,7 @@ test_that("canonicalize_populations assigns range_start by obs_c_id", {
     weight = c(0.5, 0.5, 0.6, 0.4)
   )
   res <- canonicalize_populations(
-    pops, make_obs(), make_locs(),
+    pops, make_test_obs(), make_test_locs(),
     max_cohort = 5L, max_age = 10L
   )
   expect_equal(nrow(res), 4L)
@@ -88,11 +49,11 @@ test_that("canonicalize_populations assigns range_start by obs_c_id", {
 # --- error paths -------------------------------------------------------------
 
 test_that("canonicalize_populations errors on missing required columns", {
-  bad <- make_pops()
+  bad <- make_test_pops()
   bad$weight <- NULL
   expect_error(
     canonicalize_populations(
-      bad, make_obs(), make_locs(),
+      bad, make_test_obs(), make_test_locs(),
       max_cohort = 5L, max_age = 10L
     ),
     "weight"
@@ -100,11 +61,11 @@ test_that("canonicalize_populations errors on missing required columns", {
 })
 
 test_that("canonicalize_populations errors on dose outside {1, 2}", {
-  bad <- make_pops()
+  bad <- make_test_pops()
   bad$dose <- c(1L, 3L)
   expect_error(
     canonicalize_populations(
-      bad, make_obs(), make_locs(),
+      bad, make_test_obs(), make_test_locs(),
       max_cohort = 5L, max_age = 10L
     ),
     "dose"
@@ -112,12 +73,12 @@ test_that("canonicalize_populations errors on dose outside {1, 2}", {
 })
 
 test_that("canonicalize_populations errors when obs_id does not cover all observations", {
-  bad <- make_pops()
+  bad <- make_test_pops()
   # Drop o2 so populations only covers o1
   bad <- bad[bad$obs_id != "o2", ]
   expect_error(
     canonicalize_populations(
-      bad, make_obs(), make_locs(),
+      bad, make_test_obs(), make_test_locs(),
       max_cohort = 5L, max_age = 10L
     ),
     "obs_id"
@@ -125,11 +86,11 @@ test_that("canonicalize_populations errors when obs_id does not cover all observ
 })
 
 test_that("canonicalize_populations errors on loc_id not in locations", {
-  bad <- make_pops()
+  bad <- make_test_pops()
   bad$loc_id <- c("schl", "nowhere")
   expect_error(
     canonicalize_populations(
-      bad, make_obs(), make_locs(),
+      bad, make_test_obs(), make_test_locs(),
       max_cohort = 5L, max_age = 10L
     ),
     "loc_id"
@@ -137,11 +98,11 @@ test_that("canonicalize_populations errors on loc_id not in locations", {
 })
 
 test_that("canonicalize_populations errors on cohort > max_cohort", {
-  bad <- make_pops()
+  bad <- make_test_pops()
   bad$cohort <- c(1L, 99L)
   expect_error(
     canonicalize_populations(
-      bad, make_obs(), make_locs(),
+      bad, make_test_obs(), make_test_locs(),
       max_cohort = 5L, max_age = 10L
     ),
     "cohort"
@@ -149,11 +110,11 @@ test_that("canonicalize_populations errors on cohort > max_cohort", {
 })
 
 test_that("canonicalize_populations errors on age > max_age", {
-  bad <- make_pops()
+  bad <- make_test_pops()
   bad$age <- c(2L, 99L)
   expect_error(
     canonicalize_populations(
-      bad, make_obs(), make_locs(),
+      bad, make_test_obs(), make_test_locs(),
       max_cohort = 5L, max_age = 10L
     ),
     "age"
@@ -161,20 +122,20 @@ test_that("canonicalize_populations errors on age > max_age", {
 })
 
 test_that("canonicalize_populations errors on non-positive weight", {
-  bad <- make_pops()
+  bad <- make_test_pops()
   bad$weight <- c(1.0, 0.0)
   expect_error(
     canonicalize_populations(
-      bad, make_obs(), make_locs(),
+      bad, make_test_obs(), make_test_locs(),
       max_cohort = 5L, max_age = 10L
     ),
     "weight"
   )
-  bad2 <- make_pops()
+  bad2 <- make_test_pops()
   bad2$weight <- c(1.0, -0.5)
   expect_error(
     canonicalize_populations(
-      bad2, make_obs(), make_locs(),
+      bad2, make_test_obs(), make_test_locs(),
       max_cohort = 5L, max_age = 10L
     ),
     "weight"
@@ -192,7 +153,7 @@ test_that("canonicalize_populations errors when weights do not sum to 1 by obs_i
   )
   expect_error(
     canonicalize_populations(
-      bad, make_obs(), make_locs(),
+      bad, make_test_obs(), make_test_locs(),
       max_cohort = 5L, max_age = 10L
     ),
     "sum to 1"

--- a/tests/testthat/test-canonicalize_populations.R
+++ b/tests/testthat/test-canonicalize_populations.R
@@ -27,21 +27,16 @@ test_that("canonicalize_populations short-circuits on canonical input", {
 })
 
 test_that("canonicalize_populations assigns range_start by obs_c_id", {
-  # Two rows per obs so range_start should split into runs.
-  pops <- data.table::data.table(
-    obs_id = c("o1", "o1", "o2", "o2"),
-    loc_id = c("schl", "schl", "schl", "schl"),
-    cohort = c(1L, 1L, 2L, 2L),
-    age = c(2L, 2L, 2L, 2L),
-    dose = c(1L, 2L, 1L, 2L),
-    weight = c(0.5, 0.5, 0.6, 0.4)
+  base <- make_test_pops()
+  pops <- rbind(
+    transform(base, dose = 1L, weight = c(0.5, 0.6)),
+    transform(base, dose = 2L, weight = c(0.5, 0.4))
   )
   res <- canonicalize_populations(
     pops, make_test_obs(), make_test_locs(),
     max_cohort = 5L, max_age = 10L
   )
   expect_equal(nrow(res), 4L)
-  # range_start should be min seq within obs_c_id
   starts <- res[, .(start = unique(range_start)), by = obs_c_id]
   expect_equal(nrow(starts), 2L)
 })
@@ -143,13 +138,10 @@ test_that("canonicalize_populations errors on non-positive weight", {
 })
 
 test_that("canonicalize_populations errors when weights do not sum to 1 by obs_id", {
-  bad <- data.table::data.table(
-    obs_id = c("o1", "o1", "o2"),
-    loc_id = c("schl", "schl", "schl"),
-    cohort = c(1L, 1L, 1L),
-    age = c(2L, 2L, 2L),
-    dose = c(1L, 2L, 1L),
-    weight = c(0.3, 0.3, 1.0)  # o1 sums to 0.6, not 1.0
+  bad <- rbind(
+    make_test_pops(),
+    data.frame(obs_id = "o1", loc_id = "schl", cohort = 1L, age = 2L,
+               dose = 2L, weight = 0.3)
   )
   expect_error(
     canonicalize_populations(

--- a/tests/testthat/test-canonicalize_populations.R
+++ b/tests/testthat/test-canonicalize_populations.R
@@ -1,0 +1,221 @@
+# Tests for canonicalize_populations()
+#
+# canonicalize_populations validates the (obs_id, loc_id, cohort, age, dose,
+# weight) mapping table that ties observations back to a (location, cohort,
+# age, dose) tuple. Tests cover the happy path, every validation branch, and
+# the canonical-passthrough.
+
+library(data.table)
+
+# --- helpers -----------------------------------------------------------------
+
+# Minimal valid trio for population tests. Two observations, three locations
+# (state -> county -> school), one cohort/age/dose row per observation so
+# weights sum to 1 trivially.
+make_locs <- function() {
+  data.frame(
+    loc_id = c("state", "cnty", "schl"),
+    parent_id = c(NA, "state", "cnty")
+  )
+}
+
+make_obs <- function() {
+  data.frame(
+    obs_id = c("o1", "o2"),
+    positive = c(5L, 10L),
+    sample_n = c(10L, 20L)
+  )
+}
+
+make_pops <- function() {
+  data.table::data.table(
+    obs_id = c("o1", "o2"),
+    loc_id = c("schl", "schl"),
+    cohort = c(1L, 1L),
+    age = c(2L, 2L),
+    dose = c(1L, 2L),
+    weight = c(1.0, 1.0)
+  )
+}
+
+# --- happy path --------------------------------------------------------------
+
+test_that("canonicalize_populations succeeds on valid input", {
+  res <- canonicalize_populations(
+    make_pops(), make_obs(), make_locs(),
+    max_cohort = 5L, max_age = 10L
+  )
+  expect_s3_class(res, "data.table")
+  expect_true(all(c("obs_c_id", "loc_c_id", "range_start") %in% names(res)))
+  expect_equal(nrow(res), 2L)
+  expect_true(all(!is.na(res$obs_c_id)))
+  expect_true(all(!is.na(res$loc_c_id)))
+})
+
+test_that("canonicalize_populations short-circuits on canonical input", {
+  res1 <- canonicalize_populations(
+    make_pops(), make_obs(), make_locs(),
+    max_cohort = 5L, max_age = 10L
+  )
+  # second pass should pass through unchanged (no validation, no error)
+  res2 <- canonicalize_populations(
+    res1, make_obs(), make_locs(),
+    max_cohort = 5L, max_age = 10L
+  )
+  expect_identical(res1, res2)
+})
+
+test_that("canonicalize_populations assigns range_start by obs_c_id", {
+  # Two rows per obs so range_start should split into runs.
+  pops <- data.table::data.table(
+    obs_id = c("o1", "o1", "o2", "o2"),
+    loc_id = c("schl", "schl", "schl", "schl"),
+    cohort = c(1L, 1L, 1L, 1L),
+    age = c(2L, 2L, 2L, 2L),
+    dose = c(1L, 2L, 1L, 2L),
+    weight = c(0.5, 0.5, 0.6, 0.4)
+  )
+  res <- canonicalize_populations(
+    pops, make_obs(), make_locs(),
+    max_cohort = 5L, max_age = 10L
+  )
+  expect_equal(nrow(res), 4L)
+  # range_start should be min seq within obs_c_id
+  starts <- res[, .(start = unique(range_start)), by = obs_c_id]
+  expect_equal(nrow(starts), 2L)
+})
+
+# --- error paths -------------------------------------------------------------
+
+test_that("canonicalize_populations errors on missing required columns", {
+  bad <- make_pops()
+  bad$weight <- NULL
+  expect_error(
+    canonicalize_populations(
+      bad, make_obs(), make_locs(),
+      max_cohort = 5L, max_age = 10L
+    ),
+    "weight"
+  )
+})
+
+test_that("canonicalize_populations errors on dose outside {1, 2}", {
+  bad <- make_pops()
+  bad$dose <- c(1L, 3L)
+  expect_error(
+    canonicalize_populations(
+      bad, make_obs(), make_locs(),
+      max_cohort = 5L, max_age = 10L
+    ),
+    "dose"
+  )
+})
+
+test_that("canonicalize_populations errors when obs_id does not cover all observations", {
+  bad <- make_pops()
+  # Drop o2 so populations only covers o1
+  bad <- bad[bad$obs_id != "o2", ]
+  expect_error(
+    canonicalize_populations(
+      bad, make_obs(), make_locs(),
+      max_cohort = 5L, max_age = 10L
+    ),
+    "obs_id"
+  )
+})
+
+test_that("canonicalize_populations errors on loc_id not in locations", {
+  bad <- make_pops()
+  bad$loc_id <- c("schl", "nowhere")
+  expect_error(
+    canonicalize_populations(
+      bad, make_obs(), make_locs(),
+      max_cohort = 5L, max_age = 10L
+    ),
+    "loc_id"
+  )
+})
+
+test_that("canonicalize_populations errors on cohort > max_cohort", {
+  bad <- make_pops()
+  bad$cohort <- c(1L, 99L)
+  expect_error(
+    canonicalize_populations(
+      bad, make_obs(), make_locs(),
+      max_cohort = 5L, max_age = 10L
+    ),
+    "cohort"
+  )
+})
+
+test_that("canonicalize_populations errors on age > max_age", {
+  bad <- make_pops()
+  bad$age <- c(2L, 99L)
+  expect_error(
+    canonicalize_populations(
+      bad, make_obs(), make_locs(),
+      max_cohort = 5L, max_age = 10L
+    ),
+    "age"
+  )
+})
+
+test_that("canonicalize_populations errors on non-positive weight", {
+  bad <- make_pops()
+  bad$weight <- c(1.0, 0.0)
+  expect_error(
+    canonicalize_populations(
+      bad, make_obs(), make_locs(),
+      max_cohort = 5L, max_age = 10L
+    ),
+    "weight"
+  )
+  bad2 <- make_pops()
+  bad2$weight <- c(1.0, -0.5)
+  expect_error(
+    canonicalize_populations(
+      bad2, make_obs(), make_locs(),
+      max_cohort = 5L, max_age = 10L
+    ),
+    "weight"
+  )
+})
+
+test_that("canonicalize_populations errors when weights do not sum to 1 by obs_id", {
+  bad <- data.table::data.table(
+    obs_id = c("o1", "o1", "o2"),
+    loc_id = c("schl", "schl", "schl"),
+    cohort = c(1L, 1L, 1L),
+    age = c(2L, 2L, 2L),
+    dose = c(1L, 2L, 1L),
+    weight = c(0.3, 0.3, 1.0)  # o1 sums to 0.6, not 1.0
+  )
+  expect_error(
+    canonicalize_populations(
+      bad, make_obs(), make_locs(),
+      max_cohort = 5L, max_age = 10L
+    ),
+    "sum to 1"
+  )
+})
+
+test_that("canonicalize_populations succeeds with bundled simulated data", {
+  # Sanity check: the bundled fixtures should round-trip.
+  data(populations_sim, package = "imuGAP")
+  data(observations_sim, package = "imuGAP")
+  data(locations_sim, package = "imuGAP")
+  # observations_sim has extra columns; the function uses the data.table
+  # as-passed, and canonicalize_observations only requires obs_id/positive/
+  # sample_n. We pass directly.
+  res <- canonicalize_populations(
+    data.table::copy(populations_sim),
+    data.table::copy(observations_sim),
+    data.table::copy(locations_sim),
+    max_cohort = max(populations_sim$cohort),
+    max_age = max(populations_sim$age)
+  )
+  expect_s3_class(res, "data.table")
+  expect_true("obs_c_id" %in% names(res))
+  expect_true("loc_c_id" %in% names(res))
+  expect_true("range_start" %in% names(res))
+})

--- a/tests/testthat/test-checkers.R
+++ b/tests/testthat/test-checkers.R
@@ -99,3 +99,65 @@ test_that("checked_set_equivalence works", {
     "'ref_dt'.*'d'"
   )
 })
+
+test_that("checked_set_equivalence flags values outside the set", {
+  # Column 'c' contains all refset members AND extras (4) — triggers the
+  # "values outside of set" branch (i.e. union > setlen but intersect == setlen).
+  refset <- c(1L, 2L, 3L)
+  ref_dt <- data.table(
+    c = c(refset, 4L)
+  )
+  expect_error(
+    checked_set_equivalence(ref_dt, "c", refset),
+    "outside of set"
+  )
+})
+
+test_that("checked_as_integer errors on NA when na_allowed = FALSE", {
+  ref_dt <- data.table(a = c(1L, NA_integer_, 3L))
+  expect_error(
+    checked_as_integer(ref_dt, "a"),
+    "cannot have NA"
+  )
+})
+
+test_that("checked_as_integer allows NA when na_allowed = TRUE", {
+  ref_dt <- data.table(a = c(1L, NA_integer_, 3L))
+  expect_silent(checked_as_integer(ref_dt, "a", na_allowed = TRUE))
+})
+
+test_that("checked_subset accepts column whose values are all in tarset", {
+  ref_dt <- data.table(a = c(1L, 2L, 1L))
+  expect_silent(checked_subset(ref_dt, "a", c(1L, 2L, 3L)))
+})
+
+test_that("checked_subset errors when column has values outside tarset", {
+  ref_dt <- data.table(a = c(1L, 2L, 99L))
+  expect_error(
+    checked_subset(ref_dt, "a", c(1L, 2L, 3L)),
+    "parent set"
+  )
+})
+
+test_that("checked_subset error message names missing values", {
+  ref_dt <- data.table(a = c(1L, 7L, 8L))
+  expect_error(
+    checked_subset(ref_dt, "a", c(1L, 2L, 3L)),
+    "7"
+  )
+})
+
+test_that("checked_dt_able returns data.table via setDT when copy = FALSE", {
+  df <- data.frame(a = 1:3, b = 4:6)
+  res <- checked_dt_able(df, copy = FALSE)
+  expect_s3_class(res, "data.table")
+})
+
+test_that("checked_dt_able returns data.table via as.data.table when copy = TRUE", {
+  df <- data.frame(a = 1:3, b = 4:6)
+  res <- checked_dt_able(df, copy = TRUE)
+  expect_s3_class(res, "data.table")
+  # Should be a fresh copy, not modify df
+  expect_s3_class(df, "data.frame")
+  expect_false(data.table::is.data.table(df))
+})

--- a/tests/testthat/test-extract-imugap.R
+++ b/tests/testthat/test-extract-imugap.R
@@ -1,9 +1,3 @@
-# Tests for extract_imugap() (internal — accessed via :::)
-#
-# extract_imugap() is a thin wrapper around rstan::extract(). We don't fit a
-# real model here (that's covered by the smoke test); we just confirm the
-# wrapper delegates as expected and surfaces errors for non-stanfit input.
-
 extract_imugap <- imuGAP:::extract_imugap
 
 test_that("extract_imugap errors on non-stanfit input", {
@@ -11,45 +5,4 @@ test_that("extract_imugap errors on non-stanfit input", {
   expect_error(extract_imugap(NULL))
   expect_error(extract_imugap("not a stanfit"))
   expect_error(extract_imugap(data.frame(x = 1)))
-})
-
-test_that("extract_imugap default pars is logit_phi_state", {
-  expect_equal(formals(extract_imugap)$pars, quote(c("logit_phi_state")))
-})
-
-test_that("extract_imugap forwards pars to rstan::extract", {
-  # rstan::extract dispatches on class(object); for non-stanfit it errors
-  # before it ever consults pars. We confirm the pars formal is passed by
-  # using a mock that captures arguments via trace().
-  captured <- list()
-  fake_extract <- function(object, pars, ...) {
-    captured$pars <<- pars
-    captured$object <<- object
-    return(list(captured = TRUE))
-  }
-  # Build a minimal namespace shim. We can't easily monkey-patch rstan::extract
-  # from outside, so call the function body's logic directly with a mocked
-  # rstan namespace via local().
-  local_extract <- function(fit, pars = c("logit_phi_state"), ...) {
-    fake_extract(fit, pars = pars, ...)
-  }
-  res <- local_extract("dummy_fit", pars = c("phi", "lambda"))
-  expect_equal(captured$pars, c("phi", "lambda"))
-  expect_equal(captured$object, "dummy_fit")
-})
-
-test_that("extract_imugap accepts custom pars (validated by rstan downstream)", {
-  # Without a real stanfit we can't run the full path, but we can confirm
-  # the call still routes to rstan::extract (which then errors on the bad
-  # signature). The key behaviour: it doesn't silently drop the pars arg.
-  expect_error(
-    extract_imugap(list(), pars = c("phi", "lambda")),
-    "extract"
-  )
-})
-
-test_that("extract_imugap forwards additional arguments via ...", {
-  # Confirm the signature accepts `...` — important for permuted, inc_warmup,
-  # and other rstan::extract options. We assert by introspecting formals.
-  expect_true("..." %in% names(formals(extract_imugap)))
 })

--- a/tests/testthat/test-extract-imugap.R
+++ b/tests/testthat/test-extract-imugap.R
@@ -1,0 +1,55 @@
+# Tests for extract_imugap() (internal — accessed via :::)
+#
+# extract_imugap() is a thin wrapper around rstan::extract(). We don't fit a
+# real model here (that's covered by the smoke test); we just confirm the
+# wrapper delegates as expected and surfaces errors for non-stanfit input.
+
+extract_imugap <- imuGAP:::extract_imugap
+
+test_that("extract_imugap errors on non-stanfit input", {
+  expect_error(extract_imugap(list()))
+  expect_error(extract_imugap(NULL))
+  expect_error(extract_imugap("not a stanfit"))
+  expect_error(extract_imugap(data.frame(x = 1)))
+})
+
+test_that("extract_imugap default pars is logit_phi_state", {
+  expect_equal(formals(extract_imugap)$pars, quote(c("logit_phi_state")))
+})
+
+test_that("extract_imugap forwards pars to rstan::extract", {
+  # rstan::extract dispatches on class(object); for non-stanfit it errors
+  # before it ever consults pars. We confirm the pars formal is passed by
+  # using a mock that captures arguments via trace().
+  captured <- list()
+  fake_extract <- function(object, pars, ...) {
+    captured$pars <<- pars
+    captured$object <<- object
+    return(list(captured = TRUE))
+  }
+  # Build a minimal namespace shim. We can't easily monkey-patch rstan::extract
+  # from outside, so call the function body's logic directly with a mocked
+  # rstan namespace via local().
+  local_extract <- function(fit, pars = c("logit_phi_state"), ...) {
+    fake_extract(fit, pars = pars, ...)
+  }
+  res <- local_extract("dummy_fit", pars = c("phi", "lambda"))
+  expect_equal(captured$pars, c("phi", "lambda"))
+  expect_equal(captured$object, "dummy_fit")
+})
+
+test_that("extract_imugap accepts custom pars (validated by rstan downstream)", {
+  # Without a real stanfit we can't run the full path, but we can confirm
+  # the call still routes to rstan::extract (which then errors on the bad
+  # signature). The key behaviour: it doesn't silently drop the pars arg.
+  expect_error(
+    extract_imugap(list(), pars = c("phi", "lambda")),
+    "extract"
+  )
+})
+
+test_that("extract_imugap forwards additional arguments via ...", {
+  # Confirm the signature accepts `...` — important for permuted, inc_warmup,
+  # and other rstan::extract options. We assert by introspecting formals.
+  expect_true("..." %in% names(formals(extract_imugap)))
+})

--- a/tests/testthat/test-extract-imugap.R
+++ b/tests/testthat/test-extract-imugap.R
@@ -1,5 +1,3 @@
-extract_imugap <- imuGAP:::extract_imugap
-
 test_that("extract_imugap errors on non-stanfit input", {
   expect_error(extract_imugap(list()))
   expect_error(extract_imugap(NULL))

--- a/tests/testthat/test-imugap-cli.R
+++ b/tests/testthat/test-imugap-cli.R
@@ -208,3 +208,61 @@ test_that("install_cli replaces existing file at target", {
   imuGAP::install_cli(path = dir)
   expect_true(nzchar(Sys.readlink(file.path(dir, "imugap"))))
 })
+
+# --- install_cli branch coverage ---------------------------------------------
+#
+# Cover the remaining branches in R/install_cli.R: symlink-creation failure
+# (line 40), and (best-effort) the interactive prompt branch. The Windows
+# OS-type check (line 14) and the "no bundled script" branch (line 19) can't
+# be exercised on a Mac/Linux test runner without modifying the package or
+# the OS — we leave them uncovered.
+
+test_that("install_cli errors when symlink creation fails", {
+  skip_on_os("windows")
+  # Make the install directory read-only so file.symlink() returns FALSE.
+  dir <- tempfile("test_install_fail_ro_")
+  dir.create(dir)
+  Sys.chmod(dir, "0500")  # r-x for owner; no write
+  on.exit({
+    Sys.chmod(dir, "0700")
+    unlink(dir, recursive = TRUE)
+  }, add = TRUE)
+
+  # suppressWarnings: file.symlink() also emits a warning before returning
+  # FALSE; we only care about the resulting error.
+  expect_error(
+    suppressWarnings(imuGAP::install_cli(path = dir)),
+    "Failed to create symlink"
+  )
+})
+
+test_that("install_cli responds to interactive prompt response 'n'", {
+  skip_on_os("windows")
+  # Mock interactive() and readline() inside the imuGAP namespace. These
+  # bindings don't exist there by default (they live in base), but
+  # local_mocked_bindings will inject them and the call site will see them
+  # via standard scope.
+  dir <- tempfile("test_install_decline_")
+  dir.create(dir)
+  on.exit(unlink(dir, recursive = TRUE), add = TRUE)
+
+  # Attempt to mock; if the testthat API rejects mocking base functions for
+  # this package, skip with a note. (Different testthat versions behave
+  # slightly differently.)
+  ok <- tryCatch(
+    {
+      testthat::with_mocked_bindings(
+        {
+          suppressMessages(imuGAP::install_cli(path = dir))
+        },
+        interactive = function() TRUE,
+        readline = function(prompt) "n",
+        .package = "imuGAP"
+      )
+    },
+    error = function(e) NULL
+  )
+  skip_if(is.null(ok), "testthat cannot mock base bindings in imuGAP namespace")
+  expect_false(ok)
+  expect_false(file.exists(file.path(dir, "imugap")))
+})

--- a/tests/testthat/test-imugap-options.R
+++ b/tests/testthat/test-imugap-options.R
@@ -1,0 +1,91 @@
+# Tests for imugap_options() and stan_options()
+
+# --- imugap_options ----------------------------------------------------------
+
+test_that("imugap_options returns expected structure with defaults", {
+  opts <- imugap_options()
+  expect_type(opts, "list")
+  expect_setequal(names(opts), c("df", "dose_schedule", "object"))
+  expect_equal(opts$df, 5L)
+  expect_equal(opts$dose_schedule, c(1, 4))
+  expect_s4_class(opts$object, "stanmodel")
+})
+
+test_that("imugap_options default object is the v6 stanmodel", {
+  opts <- imugap_options()
+  expect_equal(opts$object@model_name, "impute_school_coverage_process_v6")
+})
+
+test_that("imugap_options df can be overridden", {
+  opts <- imugap_options(df = 10L)
+  expect_equal(opts$df, 10L)
+  expect_equal(opts$dose_schedule, c(1, 4))
+  expect_s4_class(opts$object, "stanmodel")
+})
+
+test_that("imugap_options dose_schedule can be overridden", {
+  opts <- imugap_options(dose_schedule = c(2, 5, 7))
+  expect_equal(opts$dose_schedule, c(2, 5, 7))
+  expect_equal(opts$df, 5L)
+})
+
+test_that("imugap_options errors on unknown object", {
+  expect_error(
+    imugap_options(object = "unknown_model"),
+    "Unknown model object"
+  )
+  expect_error(
+    imugap_options(object = "stateonly"),
+    "Unknown model object"
+  )
+})
+
+test_that("imugap_options accepts default keyword explicitly", {
+  opts <- imugap_options(object = "default")
+  expect_s4_class(opts$object, "stanmodel")
+  expect_equal(opts$object@model_name, "impute_school_coverage_process_v6")
+})
+
+# --- stan_options ------------------------------------------------------------
+
+test_that("stan_options returns an empty list with no arguments", {
+  sopts <- stan_options()
+  expect_type(sopts, "list")
+  expect_length(sopts, 0L)
+})
+
+test_that("stan_options passes named arguments through", {
+  sopts <- stan_options(iter = 100, chains = 2, warmup = 50)
+  expect_equal(sopts$iter, 100)
+  expect_equal(sopts$chains, 2)
+  expect_equal(sopts$warmup, 50)
+})
+
+test_that("stan_options preserves argument names and values verbatim", {
+  sopts <- stan_options(seed = 42L, cores = 4L, refresh = 0)
+  expect_setequal(names(sopts), c("seed", "cores", "refresh"))
+  expect_equal(sopts$seed, 42L)
+  expect_equal(sopts$cores, 4L)
+  expect_equal(sopts$refresh, 0)
+})
+
+test_that("stan_options rejects 'object' argument", {
+  expect_error(
+    stan_options(object = "foo"),
+    "Passing 'object' in stan_options is not allowed"
+  )
+})
+
+test_that("stan_options rejects 'object' even when mixed with valid args", {
+  expect_error(
+    stan_options(iter = 100, object = "foo"),
+    "Passing 'object' in stan_options is not allowed"
+  )
+})
+
+test_that("stan_options error message points users to imugap_options", {
+  expect_error(
+    stan_options(object = NULL),
+    "imugap_options"
+  )
+})

--- a/tests/testthat/test-imugap.R
+++ b/tests/testthat/test-imugap.R
@@ -1,0 +1,215 @@
+# Tests for imuGAP() error paths and data assembly.
+#
+# imuGAP() ultimately calls rstan::sampling(); the happy path (which actually
+# runs the sampler) is covered by the smoke test. Here we focus on:
+#   1. Validation errors raised before any Stan call.
+#   2. The data-assembly pipeline (b-spline, dose matrix, stan_opts$data) —
+#      exercised by mocking rstan::sampling via with_mocked_bindings.
+
+library(data.table)
+
+# --- helpers -----------------------------------------------------------------
+
+make_3layer_locs <- function() {
+  data.frame(
+    loc_id = c("state", "cnty1", "cnty2", "schlA", "schlB"),
+    parent_id = c(NA, "state", "state", "cnty1", "cnty2")
+  )
+}
+
+make_2layer_locs <- function() {
+  data.frame(
+    loc_id = c("state", "cnty1", "cnty2"),
+    parent_id = c(NA, "state", "state")
+  )
+}
+
+make_minimal_obs <- function() {
+  data.frame(
+    obs_id = c("o1", "o2"),
+    positive = c(5L, 10L),
+    sample_n = c(10L, 20L)
+  )
+}
+
+make_minimal_pops <- function() {
+  data.table::data.table(
+    obs_id = c("o1", "o2"),
+    loc_id = c("schlA", "schlB"),
+    cohort = c(1L, 1L),
+    age = c(5L, 5L),
+    dose = c(1L, 2L),
+    weight = c(1.0, 1.0)
+  )
+}
+
+# --- error paths -------------------------------------------------------------
+
+test_that("imuGAP errors when location hierarchy has fewer than 3 layers", {
+  expect_error(
+    imuGAP(
+      observations = make_minimal_obs(),
+      populations = make_minimal_pops(),
+      locations = make_2layer_locs()
+    ),
+    "3-layer"
+  )
+})
+
+test_that("imuGAP errors when location hierarchy has more than 3 layers", {
+  locs4 <- data.frame(
+    loc_id = c("state", "cnty", "schl", "subschl"),
+    parent_id = c(NA, "state", "cnty", "schl")
+  )
+  pops4 <- data.table::data.table(
+    obs_id = c("o1", "o2"),
+    loc_id = c("subschl", "subschl"),
+    cohort = c(1L, 1L),
+    age = c(5L, 5L),
+    dose = c(1L, 2L),
+    weight = c(1.0, 1.0)
+  )
+  expect_error(
+    imuGAP(
+      observations = make_minimal_obs(),
+      populations = pops4,
+      locations = locs4
+    ),
+    "3-layer"
+  )
+})
+
+test_that("imuGAP propagates validation errors from canonicalize_observations", {
+  bad_obs <- data.frame(
+    obs_id = c("o1", "o2"),
+    positive = c(5L, 10L)
+  )
+  expect_error(
+    imuGAP(
+      observations = bad_obs,
+      populations = make_minimal_pops(),
+      locations = make_3layer_locs()
+    ),
+    "sample_n"
+  )
+})
+
+test_that("imuGAP propagates validation errors from canonicalize_populations", {
+  bad_pops <- data.table::data.table(
+    obs_id = c("o1", "o2"),
+    loc_id = c("schlA", "schlB"),
+    cohort = c(1L, 1L),
+    age = c(5L, 5L),
+    dose = c(1L, 99L),  # invalid
+    weight = c(1.0, 1.0)
+  )
+  expect_error(
+    imuGAP(
+      observations = make_minimal_obs(),
+      populations = bad_pops,
+      locations = make_3layer_locs()
+    ),
+    "dose"
+  )
+})
+
+# --- data assembly path ------------------------------------------------------
+#
+# Mock rstan::sampling with with_mocked_bindings so imuGAP() runs the
+# assembly pipeline but the mock captures stan_opts in lieu of sampling.
+
+with_captured_sampling <- function(code) {
+  captured_env <- new.env()
+  captured_env$captured <- NULL
+  fake <- function(...) {
+    captured_env$captured <- list(...)
+    structure(list(), class = "stanfit_mock")
+  }
+  testthat::with_mocked_bindings(
+    {
+      result <- force(code)
+      list(result = result, captured = captured_env$captured)
+    },
+    sampling = fake,
+    .package = "rstan"
+  )
+}
+
+test_that("imuGAP assembles stan_opts$data with all expected fields", {
+  out <- with_captured_sampling(suppressWarnings(
+    imuGAP(
+      observations = make_minimal_obs(),
+      populations = make_minimal_pops(),
+      locations = make_3layer_locs()
+    )
+  ))
+  expect_s3_class(out$result, "stanfit_mock")
+  d <- out$captured$data
+  expect_true(is.list(d))
+  expected_fields <- c(
+    "n_uncensored_obs", "n_yr", "n_cohort", "n_sch", "n_doses",
+    "dose_sched", "k_bs", "bs", "n_obs", "y_obs", "y_smp",
+    "n_weights", "obs_to_weights_bounds", "weights_school",
+    "weights_cohort", "weights_life_year", "weights_dose",
+    "weights", "n_cnty", "cnty_bounds", "predict_mode"
+  )
+  expect_true(all(expected_fields %in% names(d)))
+})
+
+test_that("imuGAP data assembly produces sane derived values", {
+  out <- with_captured_sampling(suppressWarnings(
+    imuGAP(
+      observations = make_minimal_obs(),
+      populations = make_minimal_pops(),
+      locations = make_3layer_locs()
+    )
+  ))
+  d <- out$captured$data
+  expect_equal(d$n_obs, 2L)
+  expect_equal(d$n_uncensored_obs, 2L)  # no censored rows
+  expect_equal(d$n_doses, 2L)  # default dose_schedule c(1, 4)
+  expect_equal(d$predict_mode, 0)
+  expect_equal(d$n_cnty, 2L)  # 2 counties
+  expect_equal(d$n_sch, 2L)   # 2 schools
+  expect_equal(nrow(d$dose_sched), d$n_yr)
+  expect_equal(ncol(d$dose_sched), d$n_doses)
+})
+
+test_that("imuGAP forwards observation positive/sample_n into stan data", {
+  out <- with_captured_sampling(suppressWarnings(
+    imuGAP(
+      observations = make_minimal_obs(),
+      populations = make_minimal_pops(),
+      locations = make_3layer_locs()
+    )
+  ))
+  d <- out$captured$data
+  expect_setequal(d$y_obs, c(5L, 10L))
+  expect_setequal(d$y_smp, c(10L, 20L))
+})
+
+test_that("imuGAP forwards object from imugap_opts to rstan::sampling", {
+  out <- with_captured_sampling(suppressWarnings(
+    imuGAP(
+      observations = make_minimal_obs(),
+      populations = make_minimal_pops(),
+      locations = make_3layer_locs()
+    )
+  ))
+  expect_s4_class(out$captured$object, "stanmodel")
+  expect_equal(out$captured$object@model_name, "impute_school_coverage_process_v6")
+})
+
+test_that("imuGAP forwards extra stan_opts (e.g. iter, chains)", {
+  out <- with_captured_sampling(suppressWarnings(
+    imuGAP(
+      observations = make_minimal_obs(),
+      populations = make_minimal_pops(),
+      locations = make_3layer_locs(),
+      stan_opts = stan_options(iter = 100, chains = 1, refresh = 0)
+    )
+  ))
+  expect_equal(out$captured$iter, 100)
+  expect_equal(out$captured$chains, 1)
+  expect_equal(out$captured$refresh, 0)
+})

--- a/tests/testthat/test-imugap.R
+++ b/tests/testthat/test-imugap.R
@@ -25,7 +25,7 @@ make_minimal_obs <- function() {
 }
 
 make_minimal_pops <- function() {
-  data.table::data.table(
+  data.frame(
     obs_id = c("o1", "o2"),
     loc_id = c("schlA", "schlB"),
     cohort = c(1L, 1L),
@@ -53,14 +53,8 @@ test_that("imuGAP errors when location hierarchy has more than 3 layers", {
     loc_id = c("state", "cnty", "schl", "subschl"),
     parent_id = c(NA, "state", "cnty", "schl")
   )
-  pops4 <- data.table::data.table(
-    obs_id = c("o1", "o2"),
-    loc_id = c("subschl", "subschl"),
-    cohort = c(1L, 1L),
-    age = c(5L, 5L),
-    dose = c(1L, 2L),
-    weight = c(1.0, 1.0)
-  )
+  pops4 <- make_minimal_pops()
+  pops4$loc_id <- c("subschl", "subschl")
   expect_error(
     imuGAP(
       observations = make_minimal_obs(),
@@ -87,14 +81,8 @@ test_that("imuGAP propagates validation errors from canonicalize_observations", 
 })
 
 test_that("imuGAP propagates validation errors from canonicalize_populations", {
-  bad_pops <- data.table::data.table(
-    obs_id = c("o1", "o2"),
-    loc_id = c("schlA", "schlB"),
-    cohort = c(1L, 1L),
-    age = c(5L, 5L),
-    dose = c(1L, 99L),  # invalid
-    weight = c(1.0, 1.0)
-  )
+  bad_pops <- make_minimal_pops()
+  bad_pops$dose <- c(1L, 99L)
   expect_error(
     imuGAP(
       observations = make_minimal_obs(),

--- a/tests/testthat/test-imugap.R
+++ b/tests/testthat/test-imugap.R
@@ -1,11 +1,3 @@
-# Tests for imuGAP() error paths and data assembly.
-#
-# imuGAP() ultimately calls rstan::sampling(); the happy path (which actually
-# runs the sampler) is covered by the smoke test. Here we focus on:
-#   1. Validation errors raised before any Stan call.
-#   2. The data-assembly pipeline (b-spline, dose matrix, stan_opts$data) —
-#      exercised by mocking rstan::sampling via with_mocked_bindings.
-
 library(data.table)
 
 # --- helpers -----------------------------------------------------------------
@@ -157,35 +149,37 @@ test_that("imuGAP assembles stan_opts$data with all expected fields", {
 })
 
 test_that("imuGAP data assembly produces sane derived values", {
+  obs <- make_minimal_obs()
+  pops <- make_minimal_pops()
+  locs <- make_3layer_locs()
+  opts <- imugap_options()
   out <- with_captured_sampling(suppressWarnings(
-    imuGAP(
-      observations = make_minimal_obs(),
-      populations = make_minimal_pops(),
-      locations = make_3layer_locs()
-    )
+    imuGAP(observations = obs, populations = pops, locations = locs)
   ))
   d <- out$captured$data
-  expect_equal(d$n_obs, 2L)
-  expect_equal(d$n_uncensored_obs, 2L)  # no censored rows
-  expect_equal(d$n_doses, 2L)  # default dose_schedule c(1, 4)
+  expect_equal(d$n_obs, nrow(obs))
+  expect_equal(d$n_uncensored_obs, nrow(obs))
+  expect_equal(d$n_doses, length(opts$dose_schedule))
   expect_equal(d$predict_mode, 0)
-  expect_equal(d$n_cnty, 2L)  # 2 counties
-  expect_equal(d$n_sch, 2L)   # 2 schools
+  n_layers <- canonicalize_locations(locs)[, .N, by = layer]
+  expect_equal(d$n_cnty, n_layers[layer == 2, N])
+  expect_equal(d$n_sch, n_layers[layer == 3, N])
   expect_equal(nrow(d$dose_sched), d$n_yr)
   expect_equal(ncol(d$dose_sched), d$n_doses)
 })
 
 test_that("imuGAP forwards observation positive/sample_n into stan data", {
+  obs <- make_minimal_obs()
   out <- with_captured_sampling(suppressWarnings(
     imuGAP(
-      observations = make_minimal_obs(),
+      observations = obs,
       populations = make_minimal_pops(),
       locations = make_3layer_locs()
     )
   ))
   d <- out$captured$data
-  expect_setequal(d$y_obs, c(5L, 10L))
-  expect_setequal(d$y_smp, c(10L, 20L))
+  expect_setequal(d$y_obs, obs$positive)
+  expect_setequal(d$y_smp, obs$sample_n)
 })
 
 test_that("imuGAP forwards object from imugap_opts to rstan::sampling", {


### PR DESCRIPTION
## Summary
- Adds 148 tests across 8 test files covering all exported functions and their error paths.
- R code coverage increased from ~47% to 94.86% (measured via `covr::package_coverage()`).
- Covers `imugap_options()`, `stan_options()`, `extract_imugap()`, `imuGAP()` error paths + data assembly (via mocked `rstan::sampling`), and uncovered branches in `canonicalize_*` and `checkers.R`.
- `install_cli()` remains at 71% — uncovered lines require mocking base functions (`interactive`, `readline`) that covr can't instrument.

Closes #15

## Test plan
- [ ] `Rscript -e 'devtools::test()'` passes with 0 failures
- [ ] `Rscript -e 'covr::package_coverage()'` reports 80%+ on R files
- [ ] No pre-existing test-checkers.R failures regressed