### PR TITLE
Add issue templates and update CONTRIBUTING

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,41 @@
+name: Bug Report
+description: Report something that isn't working correctly
+labels: ["bug"]
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: What happened, and what did you expect to happen?
+    validations:
+      required: true
+
+  - type: textarea
+    id: reprex
+    attributes:
+      label: Minimal reproducible example
+      description: Paste a short R script that reproduces the problem. Wrap in a code fence.
+      render: r
+    validations:
+      required: false
+
+  - type: textarea
+    id: session_info
+    attributes:
+      label: Session info
+      description: Paste the output of `sessionInfo()`.
+      render: text
+    validations:
+      required: true
+
+  - type: dropdown
+    id: os
+    attributes:
+      label: Operating system
+      options:
+        - macOS
+        - Ubuntu / Linux
+        - Windows
+        - Other
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,27 @@
+name: Feature Request
+description: Suggest a new feature or improvement
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: use_case
+    attributes:
+      label: Use case
+      description: What problem would this feature solve? How does it fit into the imuGAP workflow?
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposed_solution
+    attributes:
+      label: Proposed solution
+      description: How do you think this should work?
+    validations:
+      required: false
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Any other approaches you have thought about.
+    validations:
+      required: false

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,18 +13,16 @@ language are not.
 
 ## Reporting Bugs
 
-Open an issue at <https://github.com/ACCIDDA/imuGAP/issues> and include:
-
-- A short, descriptive title.
-- Steps to reproduce the problem (a minimal reprex is ideal).
-- What you expected to happen vs. what actually happened.
-- Your R version (`sessionInfo()` output) and operating system.
+Use the [bug report template](https://github.com/ACCIDDA/imuGAP/issues/new?template=bug_report.yml)
+when opening a new issue. It asks for a description, a minimal reprex,
+your `sessionInfo()` output, and your operating system.
 
 ## Suggesting Features
 
-Feature requests are also welcome as issues. Please describe the use
-case and, if possible, how the feature fits into the existing model
-workflow (`imuGAP()` → Stan sampling → post-processing).
+Use the [feature request template](https://github.com/ACCIDDA/imuGAP/issues/new?template=feature_request.yml).
+Describe the use case and, if possible, how the feature fits into the
+existing model workflow (`imuGAP()` -> Stan sampling -> post-processing).
+You can also open a blank issue if neither template fits.
 
 ## Submitting Changes
 
@@ -73,7 +71,7 @@ Every pull request triggers two GitHub Actions workflows:
 
 | Workflow | What it does |
 |----------|-------------|
-| **R-CMD-check** | Runs `R CMD check` on Ubuntu and macOS. Stan models are compiled from source during the check; compilation artifacts are cached to speed up subsequent runs. |
+| **R-CMD-check** | Runs `R CMD check --as-cran` on Ubuntu, macOS, and Windows across R release, oldrel, and devel (9 jobs total). R-devel jobs are allowed to fail without blocking the PR. Stan compilation artifacts are cached per OS and R version. |
 | **pkgdown** | Builds the documentation site. On PRs this is a build-only check (no deployment); the site is deployed to GitHub Pages on pushes to `main`, published releases, and manual workflow dispatches. |
 
 Both workflows should pass before a PR is merged.


### PR DESCRIPTION
## Summary
- Adds GitHub issue templates: bug report form, feature request form, and blank issue option.
- Updates CONTRIBUTING.md to link to the new templates and reflect the expanded CI matrix from PR #34.

Closes #33

## Dependencies
Merge after PR #34 (adds the CRAN CI matrix this PR documents). May need a rebase after #34 merges to resolve conflicts in CONTRIBUTING.md.

## Test plan
- [ ] "New issue" page on GitHub shows bug report and feature request templates
- [ ] Blank issue option is available
- [ ] CONTRIBUTING.md CI section matches actual workflow behavior