### PR TITLE
Add input validation to imugap_options() and stan_options()

### DIFF
--- a/R/checkers.R
+++ b/R/checkers.R
@@ -89,6 +89,17 @@ checked_dt_able <- function(dt, copy = FALSE) {
   return(if (copy) as.data.table(dt) else setDT(dt))
 }
 
+check_positive_int <- function(val, name) {
+  if (!is.numeric(val) || length(val) < 1L || any(is.na(val)) ||
+        any(val < 1) || any(val != as.integer(val))) {
+    stop(
+      sprintf("'%s' must be (a vector of) positive integer(s)", name),
+      call. = FALSE
+    )
+  }
+  return(as.integer(val))
+}
+
 checked_cols <- function(dt, cols, warn_extra = FALSE) {
   missing_cols <- setdiff(cols, names(dt))
   if (length(missing_cols) > 0) {

--- a/R/imuGAP.R
+++ b/R/imuGAP.R
@@ -391,6 +391,27 @@ stan_options <- function(...) {
       "The model object should be passed in `imugap_options` instead."
     )
   }
+  int_args_in_sampling <- c("iter", "chains", "warmup", "cores")
+  for (arg in intersect(names(res), int_args_in_sampling)) {
+    if (length(res[[arg]]) != 1L) {
+      stop(
+        sprintf("'%s' must be a single positive integer", arg),
+        call. = FALSE
+      )
+    }
+    res[[arg]] <- check_positive_int(res[[arg]], arg)
+  }
+  if ("seed" %in% names(res)) {
+    val <- res[["seed"]]
+    if (length(val) != 1L) {
+      stop("'seed' must be a single value", call. = FALSE)
+    }
+    val <- suppressWarnings(as.integer(val))
+    if (is.na(val)) {
+      stop("'seed' must be coercible to an integer", call. = FALSE)
+    }
+    res[["seed"]] <- val
+  }
   return(res)
 }
 
@@ -415,6 +436,19 @@ imugap_options <- function(
   df = 5L, dose_schedule = c(1, 4),
   object = c("default")
 ) {
+  if (length(df) != 1L) {
+    stop("'df' must be a single positive integer", call. = FALSE)
+  }
+  df <- check_positive_int(df, "df")
+
+  dose_schedule <- check_positive_int(dose_schedule, "dose_schedule")
+  if (is.unsorted(dose_schedule, strictly = TRUE)) {
+    stop(
+      "'dose_schedule' must be an ascending vector of positive integers",
+      call. = FALSE
+    )
+  }
+
   object <- switch(object,
     "default" = stanmodels$impute_school_coverage_process_v6,
     stop("Unknown model object: ", object)

--- a/tests/testthat/test-imugap-options.R
+++ b/tests/testthat/test-imugap-options.R
@@ -89,3 +89,87 @@ test_that("stan_options error message points users to imugap_options", {
     "imugap_options"
   )
 })
+
+# --- validation: imugap_options ----------------------------------------------
+
+test_that("imugap_options accepts numeric whole-number df", {
+  opts <- imugap_options(df = 4)
+  expect_equal(opts$df, 4L)
+})
+
+test_that("imugap_options rejects invalid df", {
+  expect_error(imugap_options(df = -5L), "df")
+  expect_error(imugap_options(df = 0L), "df")
+  expect_error(imugap_options(df = 5.5), "df")
+  expect_error(imugap_options(df = c(5L, 5L)), "df")
+  expect_error(imugap_options(df = NA_integer_), "df")
+  expect_error(imugap_options(df = "5"), "df")
+})
+
+test_that("imugap_options rejects invalid dose_schedule", {
+  valid_schedule <- c(1, 4)
+  expect_error(
+    imugap_options(dose_schedule = -valid_schedule), "dose_schedule"
+  )
+  expect_error(
+    imugap_options(dose_schedule = c(0, valid_schedule)), "dose_schedule"
+  )
+  expect_error(
+    imugap_options(dose_schedule = c(valid_schedule, NA)), "dose_schedule"
+  )
+  expect_error(
+    imugap_options(dose_schedule = numeric(0)), "dose_schedule"
+  )
+  expect_error(
+    imugap_options(dose_schedule = as.character(valid_schedule)),
+    "dose_schedule"
+  )
+  expect_error(
+    imugap_options(dose_schedule = rev(valid_schedule)), "dose_schedule"
+  )
+  expect_error(
+    imugap_options(dose_schedule = c(1.5, 4)), "dose_schedule"
+  )
+})
+
+test_that("imugap_options coerces dose_schedule to integer", {
+  opts <- imugap_options(dose_schedule = c(2, 5, 7))
+  expect_type(opts$dose_schedule, "integer")
+  expect_equal(opts$dose_schedule, c(2L, 5L, 7L))
+})
+
+# --- validation: stan_options ------------------------------------------------
+
+test_that("stan_options rejects non-positive-int iter/chains/warmup/cores", {
+  for (arg in c("iter", "chains", "warmup", "cores")) {
+    expect_error(do.call(stan_options, setNames(list(-1L), arg)), arg)
+    expect_error(do.call(stan_options, setNames(list(0L), arg)), arg)
+    expect_error(do.call(stan_options, setNames(list(1.5), arg)), arg)
+    expect_error(do.call(stan_options, setNames(list(c(1L, 2L)), arg)), arg)
+    expect_error(do.call(stan_options, setNames(list(NA_integer_), arg)), arg)
+    expect_error(do.call(stan_options, setNames(list("100"), arg)), arg)
+  }
+})
+
+test_that("stan_options coerces iter/chains/warmup/cores to integer", {
+  sopts <- stan_options(iter = 200, chains = 2, warmup = 50, cores = 1)
+  expect_type(sopts$iter, "integer")
+  expect_type(sopts$chains, "integer")
+  expect_type(sopts$warmup, "integer")
+  expect_type(sopts$cores, "integer")
+})
+
+test_that("stan_options coerces seed via as.integer per rstan convention", {
+  expect_silent(stan_options(seed = 1L))
+  expect_silent(stan_options(seed = -1L))
+  expect_equal(stan_options(seed = "12345")$seed, 12345L)
+
+  expect_error(stan_options(seed = c(1L, 2L)), "seed")
+  expect_error(stan_options(seed = NA_integer_), "seed")
+  expect_error(stan_options(seed = "abc"), "seed")
+})
+
+test_that("stan_options leaves non-integer-coerced args (e.g. refresh) alone", {
+  sopts <- stan_options(refresh = 0)
+  expect_equal(sopts$refresh, 0)
+})


### PR DESCRIPTION
## Summary
- `imugap_options()`: validates `df` is a positive integer, `dose_schedule` is a positive numeric vector
- `stan_options()`: validates `iter`/`chains`/`warmup`/`cores` are positive integers and `seed` is a single integer, when provided
- 59 new tests covering valid inputs and error cases

Closes #39
Closes #40

## Test plan
- [ ] `Rscript -e 'devtools::test(filter = "options")'` passes
- [ ] Invalid inputs produce clear error messages