### PR TITLE
Add Codecov coverage badge and workflow

### DIFF
--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -1,0 +1,71 @@
+name: test-coverage
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  test-coverage:
+    runs-on: ubuntu-latest
+
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+      R_KEEP_PKG_SOURCE: yes
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Setup R
+        uses: r-lib/actions/setup-r@v2
+        with:
+          r-version: 'release'
+          use-public-rspm: true
+
+      - name: Install dependencies
+        uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          extra-packages: any::covr, any::xml2
+          needs: coverage
+
+      - name: Cache Stan compilation objects
+        uses: actions/cache@v5
+        with:
+          path: src/
+          key: ${{ runner.os }}-rrelease-stan-${{ hashFiles('inst/stan/**/*.stan', 'src/**/*.stan') }}
+          restore-keys: |
+            ${{ runner.os }}-rrelease-stan-
+
+      - name: Test coverage
+        run: |
+          cov <- covr::package_coverage(
+            quiet = FALSE,
+            clean = FALSE,
+            install_path = file.path(normalizePath(Sys.getenv("RUNNER_TEMP"), winslash = "/"), "package")
+          )
+          covr::to_cobertura(cov)
+        shell: Rscript {0}
+
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          fail_ci_if_error: ${{ github.event_name != 'pull_request' || ! github.event.pull_request.head.repo.fork }}
+          files: ./cobertura.xml
+          plugins: noop
+          disable_search: true
+          token: ${{ secrets.CODECOV_TOKEN }}
+
+      - name: Show testthat output
+        if: always()
+        run: |
+          ## --------------------------------------------------------------------
+          find '${{ runner.temp }}/package' -name 'testthat.Rout*' -exec cat '{}' \; || true
+        shell: bash
+
+      - name: Upload test results
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-test-failures
+          path: ${{ runner.temp }}/package

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -6,7 +6,7 @@ on:
   pull_request:
 
 jobs:
-  test-coverage:
+  unit-tests:
     runs-on: ubuntu-latest
 
     env:
@@ -37,7 +37,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-rrelease-stan-
 
-      - name: Test coverage
+      - name: Run tests with coverage
         run: |
           cov <- covr::package_coverage(
             quiet = FALSE,
@@ -47,14 +47,11 @@ jobs:
           covr::to_cobertura(cov)
         shell: Rscript {0}
 
-      - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v5
+      - name: Upload coverage artifact
+        uses: actions/upload-artifact@v4
         with:
-          fail_ci_if_error: ${{ github.event_name != 'pull_request' || ! github.event.pull_request.head.repo.fork }}
-          files: ./cobertura.xml
-          plugins: noop
-          disable_search: true
-          token: ${{ secrets.CODECOV_TOKEN }}
+          name: coverage-data
+          path: cobertura.xml
 
       - name: Show testthat output
         if: always()
@@ -69,3 +66,25 @@ jobs:
         with:
           name: coverage-test-failures
           path: ${{ runner.temp }}/package
+
+  coverage:
+    runs-on: ubuntu-latest
+    needs: unit-tests
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Download coverage artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: coverage-data
+
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          fail_ci_if_error: ${{ github.event_name != 'pull_request' || ! github.event.pull_request.head.repo.fork }}
+          files: ./cobertura.xml
+          plugins: noop
+          disable_search: true
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # imuGAP <img src="man/figures/logo.png" align="right" height="139" alt="imuGAP logo" />
 
+[![codecov](https://codecov.io/gh/ACCIDDA/imuGAP/branch/main/graph/badge.svg)](https://codecov.io/gh/ACCIDDA/imuGAP)
+
 `{imuGAP}` provides a fitting and imputation / prediction tool for a particular process model of vaccination uptake. The tool provides flexible trends and relationships for the elements of the process.
 
 ## Quick Start


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/test-coverage.yaml` that runs `covr::package_coverage()` and uploads to Codecov
- Adds Codecov badge to README

Note: @pearsonca may need to enable Codecov integration on the ACCIDDA org and provide a `CODECOV_TOKEN` secret for the repo.

Closes #44

## Test plan
- [ ] Workflow runs on push to main and PRs
- [ ] Badge renders on README once Codecov is configured