### PR TITLE
Add @examples to exported functions

### DIFF
--- a/R/imuGAP.R
+++ b/R/imuGAP.R
@@ -44,6 +44,15 @@ is_canonical <- function(dt, target_class) {
 #'  - `layer_bound` column, an integer starting from 1 by layer. This provides
 #'    index slice information used in the stan model.
 #'
+#' @examples
+#' data("locations_sim")
+#' locations_sim
+#' canonicalize_locations(locations_sim)
+#' # can also be provided in non-canonical order, and with an implicit root
+#' weird_locations <- subset(locations_sim, !is.na(parent_id))[
+#'   sample(nrow(locations_sim) - 1L)
+#' ]
+#' canonicalize_locations(weird_locations)
 #' @importFrom data.table as.data.table setkey data.table setattr
 #' @global .
 #' @autoglobal
@@ -174,6 +183,10 @@ canonicalize_locations <- function(locations) {
 #'  - a "censored" column; all NA, if not present in original `observations`
 #'    argument
 #'
+#' @examples
+#' data("observations_sim")
+#' observations_sim
+#' canonicalize_observations(observations_sim)
 #' @export
 #' @importFrom data.table as.data.table setkey
 #' @autoglobal
@@ -288,6 +301,10 @@ canonicalize_observations <- function(observations, drop_extra = TRUE) {
 #' - `loc_c_id`, the location id the row concerns, canonicalized to match
 #' - reordered to `obs_c_id` order
 #'
+#' @examples
+#' data("populations_sim"); data("locations_sim"); data("observations_sim")
+#' populations_sim
+#' canonicalize_populations(populations_sim, observations_sim, locations_sim)
 #' @autoglobal
 #' @export
 canonicalize_populations <- function(
@@ -360,6 +377,10 @@ canonicalize_populations <- function(
 #'
 #' @inheritDotParams rstan::sampling -object
 #'
+#' @examples
+#' stan_options()
+#' stan_options(chains = 2, iter = 500)
+#'
 #' @return a list of arguments matching [rstan::sampling()] inputs
 #' @export
 stan_options <- function(...) {
@@ -383,6 +404,10 @@ stan_options <- function(...) {
 #'   scheduled, with vector indices and doses matching
 #' @param object which stan model object to use; currently only "default" is
 #'   supported
+#'
+#' @examples
+#' imugap_options()
+#' imugap_options(dose_schedule = c(1, 3))
 #'
 #' @return a list of imuGAP model options
 #' @export
@@ -410,6 +435,16 @@ imugap_options <- function(
 #' @param stan_opts passed to `rstan::sampling` (e.g. `iter`, `chains`).
 #'
 #' @return An object of class `stanfit` returned by `rstan::sampling`
+#'
+#' @examples
+#' \dontrun{
+#' data("locations_sim"); data("observations_sim"); data("populations_sim")
+#' st_opts <- stan_options(chains = 2, iter = 500)
+#' imuGAP(
+#'   observations_sim, populations_sim, locations_sim,
+#'   stan_opts = st_opts
+#' )
+#' }
 #'
 #' @autoglobal
 #' @export

--- a/man/canonicalize_locations.Rd
+++ b/man/canonicalize_locations.Rd
@@ -47,3 +47,13 @@ ids. That order is determined by layer order, then position of parent
 within its layer, then "natural" order (i.e., whatever base R \code{\link[=sort]{sort()}}
 yields).
 }
+\examples{
+data("locations_sim")
+locations_sim
+canonicalize_locations(locations_sim)
+# can also be provided in non-canonical order, and with an implicit root
+weird_locations <- subset(locations_sim, !is.na(parent_id))[
+  sample(nrow(locations_sim) - 1L)
+]
+canonicalize_locations(weird_locations)
+}

--- a/man/canonicalize_observations.Rd
+++ b/man/canonicalize_observations.Rd
@@ -57,3 +57,8 @@ NA, and any right-censored observations with $1$. Note that $0$ is \emph{not} a
 valid value at this time; we are preserving that for potential future support
 of left-censoring.
 }
+\examples{
+data("observations_sim")
+observations_sim
+canonicalize_observations(observations_sim)
+}

--- a/man/canonicalize_populations.Rd
+++ b/man/canonicalize_populations.Rd
@@ -75,3 +75,8 @@ can imagine the units are whatever resolution is appropriate for your data:
 months, quarters, years, etc. As long as these are used consistently,
 estimation will work, and take on the unit meaning you used for input.
 }
+\examples{
+data("populations_sim"); data("locations_sim"); data("observations_sim")
+populations_sim
+canonicalize_populations(populations_sim, observations_sim, locations_sim)
+}

--- a/man/imuGAP.Rd
+++ b/man/imuGAP.Rd
@@ -56,3 +56,14 @@ An object of class \code{stanfit} returned by \code{rstan::sampling}
 This a sampler interface to convert user-friendly data into the necessary
 format to feed the immunity estimation model.
 }
+\examples{
+\dontrun{
+data("locations_sim"); data("observations_sim"); data("populations_sim")
+st_opts <- stan_options(chains = 2, iter = 500)
+imuGAP(
+  observations_sim, populations_sim, locations_sim,
+  stan_opts = st_opts
+)
+}
+
+}

--- a/man/imugap_options.Rd
+++ b/man/imugap_options.Rd
@@ -21,3 +21,8 @@ a list of imuGAP model options
 \description{
 This function encapsulates option passing for imuGAP settings.
 }
+\examples{
+imugap_options()
+imugap_options(dose_schedule = c(1, 3))
+
+}

--- a/man/stan_options.Rd
+++ b/man/stan_options.Rd
@@ -20,3 +20,8 @@ a list of arguments matching \code{\link[rstan:stanmodel-method-sampling]{rstan:
 This function encapsulates option passing to the stan sampler, with the
 exception of the model object, which is passed in \code{imugap_options}.
 }
+\examples{
+stan_options()
+stan_options(chains = 2, iter = 500)
+
+}


### PR DESCRIPTION
## Summary
Adds @examples blocks to all exported functions:
- `canonicalize_locations()` — load + canonicalize, implicit root demo
- `canonicalize_observations()` — load + canonicalize
- `canonicalize_populations()` — load all three datasets + canonicalize
- `stan_options()` — defaults and overrides
- `imugap_options()` — defaults and dose_schedule override
- `imuGAP()` — full call wrapped in `\dontrun{}`

Replaces PR #27 with a clean branch based on current main (post-#38 merge).

Closes #21

## Test plan
- [ ] `R CMD check` runs examples without error
- [ ] `pkgdown::build_site()` renders examples in function reference pages