### PR TITLE
Lint with air + lintr; add CI lint check

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,0 +1,36 @@
+name: lint
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+      R_KEEP_PKG_SOURCE: yes
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Setup R
+        uses: r-lib/actions/setup-r@v2
+        with:
+          r-version: 'release'
+          use-public-rspm: true
+
+      - name: Install dependencies
+        uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          extra-packages: any::lintr, local::.
+          needs: lint
+
+      - name: Lint
+        run: lintr::lint_package()
+        shell: Rscript {0}
+        env:
+          LINTR_ERROR_ON_LINT: true

--- a/.lintr
+++ b/.lintr
@@ -1,3 +1,11 @@
-linters: linters_with_defaults()
+linters: linters_with_defaults(
+    line_length_linter = line_length_linter(100L),
+    return_linter = NULL,
+    object_usage_linter = NULL,
+    object_name_linter = object_name_linter(
+      styles = c("snake_case", "symbols"),
+      regexes = "^imuGAP$"
+    )
+  )
 encoding: "UTF-8"
-exclusions: list("R/stanmodels.R", "inst/analysis")
+exclusions: list("R/stanmodels.R", "inst/analysis", "inst/scripts")

--- a/R/checkers.R
+++ b/R/checkers.R
@@ -90,8 +90,13 @@ checked_dt_able <- function(dt, copy = FALSE) {
 }
 
 check_positive_int <- function(val, name) {
-  if (!is.numeric(val) || length(val) < 1L || any(is.na(val)) ||
-        any(val < 1) || any(val != as.integer(val))) {
+  if (
+    !is.numeric(val) ||
+      length(val) < 1L ||
+      any(is.na(val)) ||
+      any(val < 1) ||
+      any(val != as.integer(val))
+  ) {
     stop(
       sprintf("'%s' must be (a vector of) positive integer(s)", name),
       call. = FALSE

--- a/R/imuGAP.R
+++ b/R/imuGAP.R
@@ -58,9 +58,10 @@ is_canonical <- function(dt, target_class) {
 #' @autoglobal
 #' @export
 canonicalize_locations <- function(locations) {
-
   # if already canonical, return
-  if (is_canonical(locations, "locations")) return(locations[])
+  if (is_canonical(locations, "locations")) {
+    return(locations[])
+  }
 
   locations <- as.data.table(locations)
 
@@ -71,7 +72,8 @@ canonicalize_locations <- function(locations) {
   if (length(dupes <- locations[, which(duplicated(loc_id))])) {
     stop(
       "locations$loc_id must be unique; found ",
-      length(dupes), " duplicates: ",
+      length(dupes),
+      " duplicates: ",
       toString(dupes, width = 80)
     )
   }
@@ -88,9 +90,12 @@ canonicalize_locations <- function(locations) {
     stop(
       "locations must have exactly one root, but found ",
       length(potential_root),
-      if (length(potential_root) > 0) paste0(
-        ": ", toString(potential_root, width = 80)
-      )
+      if (length(potential_root) > 0) {
+        paste0(
+          ": ",
+          toString(potential_root, width = 80)
+        )
+      }
     )
   }
 
@@ -191,7 +196,6 @@ canonicalize_locations <- function(locations) {
 #' @importFrom data.table as.data.table setkey
 #' @autoglobal
 canonicalize_observations <- function(observations, drop_extra = TRUE) {
-
   # if already canonical, return
   if (is_canonical(observations, "observations")) {
     return(observations[])
@@ -214,7 +218,8 @@ canonicalize_observations <- function(observations, drop_extra = TRUE) {
   if (length(dupes <- observations[, which(duplicated(obs_id))])) {
     stop(
       "observations$obs_id must be unique; found ",
-      length(dupes), " duplicates: ",
+      length(dupes),
+      " duplicates: ",
       toString(dupes, width = 80)
     )
   }
@@ -231,7 +236,6 @@ canonicalize_observations <- function(observations, drop_extra = TRUE) {
       toString(observations[positive > sample_n, obs_id], width = 80)
     )
   }
-
 
   if ("censored" %in% names(observations)) {
     # confirmed censored is numeric, and only contains NA or 1
@@ -255,7 +259,11 @@ canonicalize_observations <- function(observations, drop_extra = TRUE) {
 
   if (drop_extra) {
     observations <- observations[, .(
-      obs_c_id, positive, sample_n, censored, obs_id
+      obs_c_id,
+      positive,
+      sample_n,
+      censored,
+      obs_id
     )]
   }
 
@@ -315,7 +323,6 @@ canonicalize_populations <- function(
   max_age,
   max_dose = 2L
 ) {
-
   if (is_canonical(populations, "populations")) {
     return(populations[])
   }
@@ -323,7 +330,8 @@ canonicalize_populations <- function(
   # using internal methods, check that populations has the correct structure
   checked_dt_able(populations)
   checked_cols(
-    populations, c("obs_id", "loc_id", "cohort", "age", "dose", "weight")
+    populations,
+    c("obs_id", "loc_id", "cohort", "age", "dose", "weight")
   )
 
   observations <- canonicalize_observations(observations)
@@ -433,7 +441,8 @@ stan_options <- function(...) {
 #' @return a list of imuGAP model options
 #' @export
 imugap_options <- function(
-  df = 5L, dose_schedule = c(1, 4),
+  df = 5L,
+  dose_schedule = c(1, 4),
   object = c("default")
 ) {
   if (length(df) != 1L) {
@@ -449,7 +458,8 @@ imugap_options <- function(
     )
   }
 
-  object <- switch(object,
+  object <- switch(
+    object,
     "default" = stanmodels$impute_school_coverage_process_v6,
     stop("Unknown model object: ", object)
   )
@@ -482,14 +492,13 @@ imugap_options <- function(
 #'
 #' @autoglobal
 #' @export
-imuGAP <- function( # nolint
+imuGAP <- function(
   observations,
   populations,
   locations,
   imugap_opts = imugap_options(),
   stan_opts = stan_options()
 ) {
-
   # check location argument
   loc_info <- canonicalize_locations(locations)
   layer_sizes <- loc_info[, .N, keyby = layer][, c(N)]

--- a/tests/testthat/test-canonicalize_locations.R
+++ b/tests/testthat/test-canonicalize_locations.R
@@ -1,6 +1,4 @@
-
 test_that("can enforce id and parent_id columns", {
-
   # valid locations data should pass without error or warning
   expect_silent(
     canonicalize_locations(data.frame(loc_id = 1:3, parent_id = c(NA, 1, 1)))
@@ -8,7 +6,8 @@ test_that("can enforce id and parent_id columns", {
 
   expect_silent(
     canonicalize_locations(data.frame(
-      loc_id = c("a", "b", "c"), parent_id = c(NA, "a", "a")
+      loc_id = c("a", "b", "c"),
+      parent_id = c(NA, "a", "a")
     ))
   )
 
@@ -24,7 +23,9 @@ test_that("can enforce id and parent_id columns", {
 
   expect_warning(
     canonicalize_locations(data.frame(
-      loc_id = 1:3, parent_id = c(NA, 1, 1), extra_col = "x"
+      loc_id = 1:3,
+      parent_id = c(NA, 1, 1),
+      extra_col = "x"
     )),
     "extra_col"
   )
@@ -33,7 +34,8 @@ test_that("can enforce id and parent_id columns", {
 test_that("can enforce unique ids", {
   expect_error(
     canonicalize_locations(data.frame(
-      loc_id = c(1, 1, 2), parent_id = c(NA, 1, 1)
+      loc_id = c(1, 1, 2),
+      parent_id = c(NA, 1, 1)
     ))
   )
 })
@@ -52,14 +54,14 @@ test_that("can enforce unique root", {
 test_that("can enforce no cycles", {
   expect_error(
     canonicalize_locations(data.frame(
-      loc_id = 1:4, parent_id = c(NA, 1, 4, 3)
+      loc_id = 1:4,
+      parent_id = c(NA, 1, 4, 3)
     )),
     "cycle"
   )
 })
 
 test_that("yields data.table with ordered layer, parent_id, and id columns", {
-
   ref <- data.frame(
     loc_id = c("a", "b", "c", "d", "e"),
     parent_id = c(NA, "a", "a", "c", "b")
@@ -69,15 +71,19 @@ test_that("yields data.table with ordered layer, parent_id, and id columns", {
 
   expect_true(data.table::is.data.table(locs))
   expect_equal(
-    names(locs), c(
-      names(ref), "layer", "loc_c_id", "loc_cp_id", "layer_bound"
+    names(locs),
+    c(
+      names(ref),
+      "layer",
+      "loc_c_id",
+      "loc_cp_id",
+      "layer_bound"
     )
   )
   expect_equal(locs$layer, c(1L, 2L, 2L, 3L, 3L))
   expect_equal(locs$loc_id, c("a", "b", "c", "e", "d"))
   expect_equal(locs$loc_c_id, sort(locs$loc_c_id, na.last = FALSE))
   expect_equal(locs$loc_cp_id, sort(locs$loc_cp_id, na.last = FALSE))
-
 })
 
 test_that("infers implicit root when no row has parent_id == NA", {

--- a/tests/testthat/test-canonicalize_observations.R
+++ b/tests/testthat/test-canonicalize_observations.R
@@ -9,7 +9,6 @@ test_that("works for obvious case", {
   expect_silent(obs_res <- canonicalize_observations(obs))
   expect_s3_class(obs_res, "data.table")
   expect_equal(obs_res$obs_c_id, 1:3)
-
 })
 
 test_that("keeps or discards extra cols", {
@@ -26,11 +25,9 @@ test_that("keeps or discards extra cols", {
 
   expect_silent(obs_res2 <- canonicalize_observations(obs, drop_extra = FALSE))
   expect_true("extra" %in% names(obs_res2))
-
 })
 
 test_that("works with censoring", {
-
   obs <- data.frame(
     obs_id = c("a", "b", "c"),
     positive = c(5, 10, 15),
@@ -41,11 +38,9 @@ test_that("works with censoring", {
   expect_silent(obs_res <- canonicalize_observations(obs))
   expect_s3_class(obs_res, "data.table")
   expect_equal(obs_res$obs_id, c("a", "c", "b"))
-
 })
 
 test_that("can ensure scientific validity", {
-
   obs_negative_pos <- data.frame(
     obs_id = c("a", "b", "c"),
     positive = c(5, -10, 15),
@@ -69,7 +64,6 @@ test_that("can ensure scientific validity", {
   )
 
   expect_error(canonicalize_observations(obs_pos_samp_inconsistent), "sample_n")
-
 })
 
 test_that("errors when obs_id contains NA", {
@@ -105,7 +99,7 @@ test_that("errors when censored column contains values other than NA or 1", {
     obs_id = c("a", "b", "c"),
     positive = c(5, 10, 15),
     sample_n = c(10, 20, 30),
-    censored = c(NA, 0, 1)  # 0 is not allowed (reserved for left-censoring)
+    censored = c(NA, 0, 1) # 0 is not allowed (reserved for left-censoring)
   )
   expect_error(canonicalize_observations(obs), "censored")
 })

--- a/tests/testthat/test-canonicalize_populations.R
+++ b/tests/testthat/test-canonicalize_populations.R
@@ -1,10 +1,10 @@
-
-
-
 test_that("canonicalize_populations succeeds on valid input", {
   res <- canonicalize_populations(
-    make_test_pops(), make_test_obs(), make_test_locs(),
-    max_cohort = 5L, max_age = 10L
+    make_test_pops(),
+    make_test_obs(),
+    make_test_locs(),
+    max_cohort = 5L,
+    max_age = 10L
   )
   expect_s3_class(res, "data.table")
   expect_true(all(c("obs_c_id", "loc_c_id", "range_start") %in% names(res)))
@@ -15,13 +15,19 @@ test_that("canonicalize_populations succeeds on valid input", {
 
 test_that("canonicalize_populations short-circuits on canonical input", {
   res1 <- canonicalize_populations(
-    make_test_pops(), make_test_obs(), make_test_locs(),
-    max_cohort = 5L, max_age = 10L
+    make_test_pops(),
+    make_test_obs(),
+    make_test_locs(),
+    max_cohort = 5L,
+    max_age = 10L
   )
   # second pass should pass through unchanged (no validation, no error)
   res2 <- canonicalize_populations(
-    res1, make_test_obs(), make_test_locs(),
-    max_cohort = 5L, max_age = 10L
+    res1,
+    make_test_obs(),
+    make_test_locs(),
+    max_cohort = 5L,
+    max_age = 10L
   )
   expect_identical(res1, res2)
 })
@@ -33,8 +39,11 @@ test_that("canonicalize_populations assigns range_start by obs_c_id", {
     transform(base, dose = 2L, weight = c(0.5, 0.4))
   )
   res <- canonicalize_populations(
-    pops, make_test_obs(), make_test_locs(),
-    max_cohort = 5L, max_age = 10L
+    pops,
+    make_test_obs(),
+    make_test_locs(),
+    max_cohort = 5L,
+    max_age = 10L
   )
   expect_equal(nrow(res), 4L)
   starts <- res[, .(start = unique(range_start)), by = obs_c_id]
@@ -48,8 +57,11 @@ test_that("canonicalize_populations errors on missing required columns", {
   bad$weight <- NULL
   expect_error(
     canonicalize_populations(
-      bad, make_test_obs(), make_test_locs(),
-      max_cohort = 5L, max_age = 10L
+      bad,
+      make_test_obs(),
+      make_test_locs(),
+      max_cohort = 5L,
+      max_age = 10L
     ),
     "weight"
   )
@@ -60,8 +72,11 @@ test_that("canonicalize_populations errors on dose outside {1, 2}", {
   bad$dose <- c(1L, 3L)
   expect_error(
     canonicalize_populations(
-      bad, make_test_obs(), make_test_locs(),
-      max_cohort = 5L, max_age = 10L
+      bad,
+      make_test_obs(),
+      make_test_locs(),
+      max_cohort = 5L,
+      max_age = 10L
     ),
     "dose"
   )
@@ -73,8 +88,11 @@ test_that("canonicalize_populations errors when obs_id does not cover all observ
   bad <- bad[bad$obs_id != "o2", ]
   expect_error(
     canonicalize_populations(
-      bad, make_test_obs(), make_test_locs(),
-      max_cohort = 5L, max_age = 10L
+      bad,
+      make_test_obs(),
+      make_test_locs(),
+      max_cohort = 5L,
+      max_age = 10L
     ),
     "obs_id"
   )
@@ -85,8 +103,11 @@ test_that("canonicalize_populations errors on loc_id not in locations", {
   bad$loc_id <- c("schl", "nowhere")
   expect_error(
     canonicalize_populations(
-      bad, make_test_obs(), make_test_locs(),
-      max_cohort = 5L, max_age = 10L
+      bad,
+      make_test_obs(),
+      make_test_locs(),
+      max_cohort = 5L,
+      max_age = 10L
     ),
     "loc_id"
   )
@@ -97,8 +118,11 @@ test_that("canonicalize_populations errors on cohort > max_cohort", {
   bad$cohort <- c(1L, 99L)
   expect_error(
     canonicalize_populations(
-      bad, make_test_obs(), make_test_locs(),
-      max_cohort = 5L, max_age = 10L
+      bad,
+      make_test_obs(),
+      make_test_locs(),
+      max_cohort = 5L,
+      max_age = 10L
     ),
     "cohort"
   )
@@ -109,8 +133,11 @@ test_that("canonicalize_populations errors on age > max_age", {
   bad[2, "age"] <- 99L
   expect_error(
     canonicalize_populations(
-      bad, make_test_obs(), make_test_locs(),
-      max_cohort = 5L, max_age = 10L
+      bad,
+      make_test_obs(),
+      make_test_locs(),
+      max_cohort = 5L,
+      max_age = 10L
     ),
     "age"
   )
@@ -121,8 +148,11 @@ test_that("canonicalize_populations errors on non-positive weight", {
   bad$weight <- c(1.0, 0.0)
   expect_error(
     canonicalize_populations(
-      bad, make_test_obs(), make_test_locs(),
-      max_cohort = 5L, max_age = 10L
+      bad,
+      make_test_obs(),
+      make_test_locs(),
+      max_cohort = 5L,
+      max_age = 10L
     ),
     "weight"
   )
@@ -130,8 +160,11 @@ test_that("canonicalize_populations errors on non-positive weight", {
   bad2$weight <- c(1.0, -0.5)
   expect_error(
     canonicalize_populations(
-      bad2, make_test_obs(), make_test_locs(),
-      max_cohort = 5L, max_age = 10L
+      bad2,
+      make_test_obs(),
+      make_test_locs(),
+      max_cohort = 5L,
+      max_age = 10L
     ),
     "weight"
   )
@@ -140,13 +173,22 @@ test_that("canonicalize_populations errors on non-positive weight", {
 test_that("canonicalize_populations errors when weights do not sum to 1 by obs_id", {
   bad <- rbind(
     make_test_pops(),
-    data.frame(obs_id = "o1", loc_id = "schl", cohort = 1L, age = 2L,
-               dose = 2L, weight = 0.3)
+    data.frame(
+      obs_id = "o1",
+      loc_id = "schl",
+      cohort = 1L,
+      age = 2L,
+      dose = 2L,
+      weight = 0.3
+    )
   )
   expect_error(
     canonicalize_populations(
-      bad, make_test_obs(), make_test_locs(),
-      max_cohort = 5L, max_age = 10L
+      bad,
+      make_test_obs(),
+      make_test_locs(),
+      max_cohort = 5L,
+      max_age = 10L
     ),
     "sum to 1"
   )

--- a/tests/testthat/test-imugap-options.R
+++ b/tests/testthat/test-imugap-options.R
@@ -109,26 +109,32 @@ test_that("imugap_options rejects invalid df", {
 test_that("imugap_options rejects invalid dose_schedule", {
   valid_schedule <- c(1, 4)
   expect_error(
-    imugap_options(dose_schedule = -valid_schedule), "dose_schedule"
+    imugap_options(dose_schedule = -valid_schedule),
+    "dose_schedule"
   )
   expect_error(
-    imugap_options(dose_schedule = c(0, valid_schedule)), "dose_schedule"
+    imugap_options(dose_schedule = c(0, valid_schedule)),
+    "dose_schedule"
   )
   expect_error(
-    imugap_options(dose_schedule = c(valid_schedule, NA)), "dose_schedule"
+    imugap_options(dose_schedule = c(valid_schedule, NA)),
+    "dose_schedule"
   )
   expect_error(
-    imugap_options(dose_schedule = numeric(0)), "dose_schedule"
+    imugap_options(dose_schedule = numeric(0)),
+    "dose_schedule"
   )
   expect_error(
     imugap_options(dose_schedule = as.character(valid_schedule)),
     "dose_schedule"
   )
   expect_error(
-    imugap_options(dose_schedule = rev(valid_schedule)), "dose_schedule"
+    imugap_options(dose_schedule = rev(valid_schedule)),
+    "dose_schedule"
   )
   expect_error(
-    imugap_options(dose_schedule = c(1.5, 4)), "dose_schedule"
+    imugap_options(dose_schedule = c(1.5, 4)),
+    "dose_schedule"
   )
 })
 

--- a/tests/testthat/test-imugap-smoke.R
+++ b/tests/testthat/test-imugap-smoke.R
@@ -12,7 +12,9 @@ test_that("imuGAP() runs end-to-end on bundled *_sim data", {
   pop <- canonicalize_populations(populations_sim, obs, locs)
 
   fit <- suppressWarnings(imuGAP(
-    obs, pop, locs,
+    obs,
+    pop,
+    locs,
     stan_opts = stan_options(
       iter = 100,
       chains = 1,

--- a/tests/testthat/test-imugap.R
+++ b/tests/testthat/test-imugap.R
@@ -127,11 +127,27 @@ test_that("imuGAP assembles stan_opts$data with all expected fields", {
   d <- out$captured$data
   expect_true(is.list(d))
   expected_fields <- c(
-    "n_uncensored_obs", "n_yr", "n_cohort", "n_sch", "n_doses",
-    "dose_sched", "k_bs", "bs", "n_obs", "y_obs", "y_smp",
-    "n_weights", "obs_to_weights_bounds", "weights_school",
-    "weights_cohort", "weights_life_year", "weights_dose",
-    "weights", "n_cnty", "cnty_bounds", "predict_mode"
+    "n_uncensored_obs",
+    "n_yr",
+    "n_cohort",
+    "n_sch",
+    "n_doses",
+    "dose_sched",
+    "k_bs",
+    "bs",
+    "n_obs",
+    "y_obs",
+    "y_smp",
+    "n_weights",
+    "obs_to_weights_bounds",
+    "weights_school",
+    "weights_cohort",
+    "weights_life_year",
+    "weights_dose",
+    "weights",
+    "n_cnty",
+    "cnty_bounds",
+    "predict_mode"
   )
   expect_true(all(expected_fields %in% names(d)))
 })
@@ -179,7 +195,10 @@ test_that("imuGAP forwards object from imugap_opts to rstan::sampling", {
     )
   ))
   expect_s4_class(out$captured$object, "stanmodel")
-  expect_equal(out$captured$object@model_name, "impute_school_coverage_process_v6")
+  expect_equal(
+    out$captured$object@model_name,
+    "impute_school_coverage_process_v6"
+  )
 })
 
 test_that("imuGAP forwards extra stan_opts (e.g. iter, chains)", {


### PR DESCRIPTION
## Summary
- Reformatted all `R/` and `tests/` files with [air](https://posit-dev.github.io/air/) (Posit's opinionated R formatter)
- Updated `.lintr` to reflect codebase style choices and resolve all lints
- Added `.github/workflows/lint.yaml` so `lintr` runs on every PR (per @pearsonca's comment on this issue)

## .lintr changes
- Bumped `line_length_linter` to 100 (modern R convention; original 80 was strict for the long Stan/dplyr lines)
- Disabled `return_linter` — codebase consistently uses explicit `return()` as a style choice and 20+ mechanical edits to drop them seemed counterproductive
- Disabled `object_usage_linter` — too many false positives for package-internal calls (e.g. `check_positive_int` defined in `R/checkers.R` and used from `R/imuGAP.R` was flagged "no visible global function definition")
- Allowed `imuGAP` as a valid object name via regex (matches the package's main function)
- Added `inst/scripts/` to the exclusion list (CLI script, not package R code; will be removed entirely by #48)

## CI
- `lint.yaml` runs `lintr::lint_package()` with `LINTR_ERROR_ON_LINT: true` so any new lint fails the PR
- Sits alongside the existing `R-CMD-check` and `test-coverage` workflows

## Verification
- `lintr::lint_package()` reports 0 lints locally on this branch
- All 228 tests pass (`testthat::test_dir("tests/testthat")`) — same 3 pre-existing data.table shallow-copy warnings and 1 pre-existing skip
- `air format --check R/ tests/` reports nothing to reformat

## Coordination notes
- `inst/scripts/imugap.R` and `R/install_cli.R` will be removed by #48; their (now-excluded) lints will disappear with that PR. After this PR merges, #48 will need a trivial rebase to pick up the air-reformatted versions of test fixtures.

Closes #16