### PR TITLE
Exclude Stan-generated C++ from coverage via .covignore

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -6,6 +6,7 @@
 ^pkgdown$
 ^\.github$
 ^\.lintr$
+^\.covignore$
 ^air\.toml$
 ^justfile$
 ^[.]?air[.]toml$

--- a/.covignore
+++ b/.covignore
@@ -1,0 +1,12 @@
+# covr exclusion patterns. Matches gitignore-style globs against paths
+# relative to the package root. See:
+# https://cran.r-project.org/web/packages/covr/readme/README.html
+
+# Stan-generated C++ — emitted by rstantools from inst/stan/*.stan during
+# package build. There's no good way to unit-test it from R, and treating
+# it as coverable inflates the file count without measuring anything we
+# can act on. The Stan model itself is exercised by integration tests via
+# imuGAP(), but coverage is recorded against the .stan source, which
+# covr doesn't instrument anyway.
+src/stanExports_*.cc
+src/stanExports_*.h


### PR DESCRIPTION
## Summary

Adds a `.covignore` excluding the Stan-generated C++ (`src/stanExports_*.cc`, `*.h`) from coverage. Per @pearsonca's ask in #52 — there's no clean way to unit-test the generated Stan code from R, so it shouldn't count toward coverage. Pattern follows the [covr README guidance](https://cran.r-project.org/web/packages/covr/readme/README.html).

## Changes

- New `.covignore` with two glob patterns:
  - `src/stanExports_*.cc`
  - `src/stanExports_*.h`
- `.Rbuildignore` updated so `.covignore` doesn't get bundled into the built package (would otherwise produce an R CMD check note about non-standard top-level files).

## Scope decisions

- **Stan only, not Rcpp.** The issue specifically calls out Stan code. `src/RcppExports.cpp` is also auto-generated and similarly hard to test in isolation; happy to add it in a follow-up if @pearsonca wants the same treatment, but kept this PR scoped to what was asked.
- **Glob patterns over absolute paths.** Matches both currently-generated files (`stanExports_impute_school_coverage_process_stateonly.*` and `stanExports_impute_school_coverage_process_v6.*`) plus any future Stan models added under `inst/stan/`.

## Verification

The coverage workflow (`test-coverage.yaml`) runs `covr::package_coverage()`, which reads `.covignore` automatically — no workflow changes needed. CI on this PR should show the file counts in the cobertura report dropping accordingly.

Closes #52
