### PR TITLE
CRAN prep: DESCRIPTION, NEWS, cran-comments, CITATION

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -13,3 +13,5 @@
 ^\.vscode$
 ^CONTRIBUTING\.md$
 ^data-raw$
+^cran-comments\.md$
+^CITATION\.cff$

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,32 @@
+cff-version: 1.2.0
+message: "If you use this software, please cite it as below."
+title: "imuGAP: Estimate Measles Vaccine Coverage"
+abstract: >-
+  Fits Bayesian hierarchical models of measles vaccine coverage by
+  location and birth cohort, with a latent survival-style process
+  decomposing coverage into a lifetime propensity to vaccinate and a
+  time-varying force of vaccination smoothed with B-splines. Supports
+  state, county, and school random effects, and is implemented in Stan
+  via rstan.
+type: software
+version: "0.1.0"
+date-released: "2026-05-22"
+license: MIT
+repository-code: "https://github.com/ACCIDDA/imuGAP"
+url: "https://accidda.github.io/imuGAP/"
+authors:
+  - family-names: Pearson
+    given-names: Carl
+    email: carl.ab.pearson@gmail.com
+    orcid: "https://orcid.org/0000-0003-0701-7860"
+  - family-names: Smith
+    given-names: Claire Perrin
+    orcid: "https://orcid.org/0000-0003-1069-9460"
+keywords:
+  - measles
+  - vaccine-coverage
+  - bayesian
+  - hierarchical-model
+  - stan
+  - rstan
+  - epidemiology

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,6 +1,6 @@
 cff-version: 1.2.0
 message: "If you use this software, please cite it as below."
-title: "imuGAP: Estimate Measles Vaccine Coverage"
+title: "imuGAP - Immunity: Geographic and Age-Based Projection"
 abstract: >-
   Fits Bayesian hierarchical models of measles vaccine coverage by
   location and birth cohort, with a latent survival-style process

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,12 +2,11 @@ cff-version: 1.2.0
 message: "If you use this software, please cite it as below."
 title: "imuGAP - Immunity: Geographic and Age-Based Projection"
 abstract: >-
-  Fits Bayesian hierarchical models of measles vaccine coverage by
-  location and birth cohort, with a latent survival-style process
+  Fits Bayesian hierarchical models of vaccine coverage by
+  location, birth cohort, and age with a latent survival-style process
   decomposing coverage into a lifetime propensity to vaccinate and a
-  time-varying force of vaccination smoothed with B-splines. Supports
-  state, county, and school random effects, and is implemented in Stan
-  via rstan.
+  time-varying force of vaccination. Supports random effects at three 
+  hierarchical spatial units, and is implemented in Stan via rstan.
 type: software
 version: "0.1.0"
 date-released: "2026-05-22"

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: imuGAP
 Title: Estimate Measles Vaccine Coverage
-Version: 0.0.0.9000
+Version: 0.1.0
 Authors@R:
     c(person("Carl", "Pearson", email = "carl.ab.pearson@gmail.com", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0003-0701-7860")),
@@ -10,7 +10,18 @@ Authors@R:
       person("Weston", "Voglesonger", email = "westonvogle@gmail.com", role = "ctb"),
       person("Joshua", "Chen", email = "joshuazchen1@gmail.com", role = "ctb"),
       person("Minjae", "Kung", email = "minjaekung@gmail.com", role = "ctb"))
-Description: What the package does (one paragraph).
+Description: Fits Bayesian hierarchical models of measles vaccine
+    coverage by location and birth cohort. Observations of vaccination
+    status (which may aggregate across cohorts, ages, and doses) are
+    related to a latent survival-style process model that decomposes
+    coverage into a lifetime propensity to vaccinate and a
+    time-varying force of vaccination smoothed with B-splines.
+    Hierarchical location structure (e.g., state, county, school)
+    supports partial pooling via county- and school-level random
+    effects. Models are implemented in 'Stan' and fit via 'rstan'.
+    Provides helpers to validate and canonicalize user-supplied
+    locations, observations, and populations, and to extract or
+    predict coverage from fitted models.
 License: MIT + file LICENSE
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE, roclets = c("collate", "namespace", "rd",

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: imuGAP
-Title: Estimate Measles Vaccine Coverage
+Title: Immunity: Geographic and Age-Based Projection
 Version: 0.1.0
 Authors@R:
     c(person("Carl", "Pearson", email = "carl.ab.pearson@gmail.com", role = c("aut", "cre"),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -10,18 +10,16 @@ Authors@R:
       person("Weston", "Voglesonger", email = "westonvogle@gmail.com", role = "ctb"),
       person("Joshua", "Chen", email = "joshuazchen1@gmail.com", role = "ctb"),
       person("Minjae", "Kung", email = "minjaekung@gmail.com", role = "ctb"))
-Description: Fits Bayesian hierarchical models of measles vaccine
-    coverage by location and birth cohort. Observations of vaccination
-    status (which may aggregate across cohorts, ages, and doses) are
-    related to a latent survival-style process model that decomposes
+Description: Fits Bayesian hierarchical models of vaccine
+    coverage by location, birth cohort, and age. Observations 
+    of vaccination status (which may span cohorts, ages, and doses) are
+    used to fit a latent survival-style process model that decomposes
     coverage into a lifetime propensity to vaccinate and a
-    time-varying force of vaccination smoothed with B-splines.
-    Hierarchical location structure (e.g., state, county, school)
-    supports partial pooling via county- and school-level random
+    time-varying force of vaccination. Hierarchical spatial structure 
+    (e.g., state, county, school) supports partial pooling via random
     effects. Models are implemented in 'Stan' and fit via 'rstan'.
-    Provides helpers to validate and canonicalize user-supplied
-    locations, observations, and populations, and to extract or
-    predict coverage from fitted models.
+    Provides helpers to validate user-supplied input data, and to predict 
+    coverage from fitted models.
 License: MIT + file LICENSE
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE, roclets = c("collate", "namespace", "rd",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,0 +1,28 @@
+# imuGAP 0.1.0
+
+First public release. Initial feature set:
+
+- `sampling()`: fits the imuGAP Bayesian hierarchical coverage model via
+  `rstan::sampling()` and returns an `imugap_fit` object wrapping the
+  underlying `stanfit` together with model settings and dataset metadata.
+- `predict.imugap_fit()`: posterior-predicts coverage probabilities for a
+  user-supplied target population grid using `rstan::gqs()`.
+- `extract_imugap()`: convenience wrapper around `rstan::extract()` for
+  pulling out common imuGAP parameters (defaults to the state-level
+  B-spline coefficients `beta_bs`).
+- `canonicalize_locations()`, `canonicalize_observations()`,
+  `canonicalize_populations()`: validate and convert user-supplied data
+  into the canonical forms required by the sampler.
+- `imugap_options()`: configures model-side settings (B-spline degrees of
+  freedom, dose schedule, model object).
+- `stan_options()`: configures Stan sampler settings (`iter`, `chains`,
+  `seed`, etc.) with input validation.
+- Bundled Stan models:
+  - `impute_school_coverage_process_stateonly` (state-level only), and
+  - `impute_school_coverage_process_v6` (adds county- and school-level
+    random effects; current default).
+- Bundled example datasets for end-to-end examples and tests:
+  `locations_sim`, `observations_sim`, `populations_sim`, and the
+  reference `fit_sim` `stanfit` fixture.
+- pkgdown documentation site published at
+  <https://accidda.github.io/imuGAP/>.

--- a/NEWS.md
+++ b/NEWS.md
@@ -18,7 +18,6 @@ First public release. Initial feature set:
 - `stan_options()`: configures Stan sampler settings (`iter`, `chains`,
   `seed`, etc.) with input validation.
 - Bundled Stan models:
-  - `impute_school_coverage_process_stateonly` (state-level only), and
   - `impute_school_coverage_process_v6` (adds county- and school-level
     random effects; current default).
 - Bundled example datasets for end-to-end examples and tests:

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -31,7 +31,7 @@ GitHub-only project `ACCIDDA/imugap-map`.
 
 ## Notes for reviewer
 
-First submission. [Placeholder for package-specific notes — examples to
+First submission. Placeholder for package-specific notes — examples to
 consider mentioning:
 
 - imuGAP wraps Stan models built with `rstantools` and follows the

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -41,6 +41,6 @@ consider mentioning:
   `populations_sim`, `fit_sim`) are simulated and small; `fit_sim` is a
   wiring fixture for examples and tests, not a converged posterior.
 - Citation guidance: see `inst/CITATION` (or `CITATION.cff` at the
-  repo root) for how to cite imuGAP.]
+  repo root) for how to cite imuGAP.
 
 <!-- @csmith701: please replace the bracketed placeholders above with package-specific content before release. -->

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -43,4 +43,3 @@ consider mentioning:
 - Citation guidance: see `inst/CITATION` (or `CITATION.cff` at the
   repo root) for how to cite imuGAP.
 
-<!-- @csmith701: please replace the bracketed placeholders above with package-specific content before release. -->

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,0 +1,46 @@
+## R CMD check results
+
+0 errors | 0 warnings | [N] notes
+
+[Brief note about any notes. Typical notes for a first submission with
+Stan models include:
+
+- "New submission" (expected for first CRAN submission).
+- Installed package size note: imuGAP bundles compiled Stan models,
+  which can push the installed size above the usual thresholds. The
+  compiled models are required for the package's core functionality.
+- Long examples / installation time: Stan model compilation is
+  unavoidable for an rstan-based package; examples that exercise the
+  sampler are wrapped in `\dontrun{}` to keep `R CMD check` runtime
+  modest.]
+
+## Test environments
+
+- ubuntu-latest (R release, R oldrel, R devel) [GitHub Actions]
+- macos-latest (R release, R oldrel, R devel) [GitHub Actions]
+- windows-latest (R release, R oldrel, R devel) [GitHub Actions]
+- [Add win-builder (devel/release) results once run]
+- [Add R-hub results once run]
+
+Local development: [add platform + R version, e.g., macOS 14, R 4.4.x].
+
+## Downstream dependencies
+
+None on CRAN currently. The package is a dependency of the
+GitHub-only project `ACCIDDA/imugap-map`.
+
+## Notes for reviewer
+
+First submission. [Placeholder for package-specific notes — examples to
+consider mentioning:
+
+- imuGAP wraps Stan models built with `rstantools` and follows the
+  standard rstan package layout (`src/Makevars`, `src/stanExports_*`,
+  `inst/stan/`).
+- Bundled example datasets (`locations_sim`, `observations_sim`,
+  `populations_sim`, `fit_sim`) are simulated and small; `fit_sim` is a
+  wiring fixture for examples and tests, not a converged posterior.
+- Citation guidance: see `inst/CITATION` (or `CITATION.cff` at the
+  repo root) for how to cite imuGAP.]
+
+<!-- @csmith701: please replace the bracketed placeholders above with package-specific content before release. -->


### PR DESCRIPTION
PR A of #31's plan. Adds the metadata files needed for first CRAN submission. Touches only `DESCRIPTION`, 3 new top-level files, and `.Rbuildignore`.

- **`DESCRIPTION`**: replaces boilerplate `Description:` with a real summary; bumps `Version:` to `0.1.0` (per Carl's "conventional" call on #31).
- **`NEWS.md`** (new): initial `# imuGAP 0.1.0` entry enumerating the exported surface.
- **`cran-comments.md`** (new): first-submission template with `[bracketed placeholders]` for Claire to fill in package-specific content (per Carl: "draft please, then let's have @csmith701 do detailed content").
- **`CITATION.cff`** (new): CFF 1.2.0; Carl + Claire as authors with ORCIDs. `ctb` contributors omitted (easy to add if you prefer).
- **`.Rbuildignore`**: adds `cran-comments.md` + `CITATION.cff`; intentionally does NOT add `NEWS.md` (belongs in the tarball per CRAN convention).

Verified `R CMD build .` succeeds and produces `imuGAP_0.1.0.tar.gz` containing `NEWS.md` but not `cran-comments.md` / `CITATION.cff`.

@pearsonca: please confirm the `Description:` wording + version bump.
@csmith701: please fill in `cran-comments.md` placeholders before we tag the release.

Refs #31.
