### PR TITLE
add rOpenSci 'spelling' to CI for spellcheck QC

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -13,6 +13,7 @@ Authors@R:
 Description: What the package does (one paragraph).
 License: MIT + file LICENSE
 Encoding: UTF-8
+Language: en-US
 Roxygen: list(markdown = TRUE, roclets = c("collate", "namespace", "rd",
     "roxyglobals::global_roclet"))
 RoxygenNote: 7.3.3
@@ -34,13 +35,14 @@ LinkingTo:
     rstan (>= 2.18.1),
     StanHeaders (>= 2.18.0)
 SystemRequirements: GNU make
-Suggests: 
+Suggests:
     knitr,
     rmarkdown,
     testthat (>= 3.0.0),
     roxygen2,
     roxyglobals,
-    lintr
+    lintr,
+    spelling
 VignetteBuilder: knitr
 Config/testthat/edition: 3
 URL: https://accidda.github.io/imuGAP/, https://github.com/ACCIDDA/imuGAP

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -1,0 +1,5 @@
+codecov
+ge
+stan
+textrm
+toolchain

--- a/tests/spelling.R
+++ b/tests/spelling.R
@@ -1,0 +1,7 @@
+if (requireNamespace("spelling", quietly = TRUE)) {
+  spelling::spell_check_test(
+    vignettes = TRUE,
+    error = FALSE,
+    skip_on_cran = TRUE
+  )
+}


### PR DESCRIPTION
Wires up the rOpenSci [`spelling`](https://docs.ropensci.org/spelling/) package for spellcheck QC ahead of CRAN submission. Closes #71.

## Changes
- **`DESCRIPTION`**: add `spelling` to `Suggests`, set `Language: en-US` (CRAN dictionary selector)
- **`tests/spelling.R`** (new): runs `spelling::spell_check_test()` under R CMD check — no separate workflow needed; covered by the existing `R-CMD-check` and `test-coverage` workflows (Suggests are installed via `needs: check`). Uses `skip_on_cran = TRUE` / `error = FALSE`.
- **`inst/WORDLIST`** (new): seeded with current exceptions

## First pass
`spell_check_package()` flagged 5 words, all legitimate exceptions (now whitelisted), **zero real misspellings**:

| word | source | why |
|---|---|---|
| `codecov` | README | service name |
| `stan` | vignette | Stan, styled lowercase |
| `toolchain` | README | technical term |
| `ge`, `textrm` | vignette | LaTeX commands (`\ge`, `\textrm`) inside the math block |

## Notes
- Low immediate value by design — `man/` has no `.Rd` files yet, the `DESCRIPTION` description is still placeholder, and the vignette is only partially drafted (#65). The check passes trivially today and will auto-guard prose as docs land.
- Expect more LaTeX-command false positives as the vignette is completed (#65); whitelist them in `inst/WORDLIST` as they appear.