### PR TITLE
Draft cran-comments.md content (#31)

### DIFF
--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,45 +1,50 @@
 ## R CMD check results
 
-0 errors | 0 warnings | [N] notes
+0 errors | 0 warnings | 2 notes
 
-[Brief note about any notes. Typical notes for a first submission with
-Stan models include:
+This is a new submission.
 
-- "New submission" (expected for first CRAN submission).
-- Installed package size note: imuGAP bundles compiled Stan models,
-  which can push the installed size above the usual thresholds. The
-  compiled models are required for the package's core functionality.
-- Long examples / installation time: Stan model compilation is
-  unavoidable for an rstan-based package; examples that exercise the
-  sampler are wrapped in `\dontrun{}` to keep `R CMD check` runtime
-  modest.]
+* **New submission.** First release of imuGAP to CRAN.
+
+* **Installed package size.** imuGAP is an `rstan`-based package: it bundles
+  compiled Stan models (`src/stanExports_*`, `inst/stan/`), which push the
+  installed size above the usual threshold. The compiled models are required
+  for the package's core functionality and cannot be reduced without removing
+  it.
+
+* **S3 generic/method consistency** (`summary.imugap_predict`). [csmith701:
+  confirm wording. The `summary` method for `imugap_predict` objects takes
+  additional arguments beyond the `summary()` generic; tracked separately in
+  ACCIDDA/imuGAP#73.]
+
+(Stan model compilation also makes installation and any sampler-exercising
+examples slow; such examples are wrapped in `\dontrun{}` to keep check runtime
+modest.)
 
 ## Test environments
 
-- ubuntu-latest (R release, R oldrel, R devel) [GitHub Actions]
-- macos-latest (R release, R oldrel, R devel) [GitHub Actions]
+- ubuntu-latest (R release, R oldrel, R devel) [GitHub Actions]: 0 errors, 0 warnings
+- macos-latest (R release, R oldrel, R devel) [GitHub Actions]: 0 errors, 0 warnings
 - windows-latest (R release, R oldrel, R devel) [GitHub Actions]
-- [Add win-builder (devel/release) results once run]
-- [Add R-hub results once run]
+- [TODO before submission: win-builder (devel + release) results]
+- [TODO before submission: R-hub results]
 
-Local development: [add platform + R version, e.g., macOS 14, R 4.4.x].
+Local development: [TODO: add platform + R version].
 
 ## Downstream dependencies
 
-None on CRAN currently. The package is a dependency of the
-GitHub-only project `ACCIDDA/imugap-map`.
+None on CRAN currently. The package is a dependency of the GitHub-only project
+`ACCIDDA/imugap-map`.
 
 ## Notes for reviewer
 
-First submission. Placeholder for package-specific notes — examples to
-consider mentioning:
+[csmith701 to set the reviewer-facing voice; draft below per @pearsonca on #31.]
 
-- imuGAP wraps Stan models built with `rstantools` and follows the
-  standard rstan package layout (`src/Makevars`, `src/stanExports_*`,
-  `inst/stan/`).
+First submission. Points that may be useful to the reviewer:
+
+- imuGAP wraps Stan models built with `rstantools` and follows the standard
+  rstan package layout (`src/Makevars`, `src/stanExports_*`, `inst/stan/`).
 - Bundled example datasets (`locations_sim`, `observations_sim`,
-  `populations_sim`, `fit_sim`) are simulated and small; `fit_sim` is a
-  wiring fixture for examples and tests, not a converged posterior.
-- Citation guidance: see `inst/CITATION` (or `CITATION.cff` at the
-  repo root) for how to cite imuGAP.
-
+  `populations_sim`, `fit_sim`) are simulated and small; `fit_sim` is a wiring
+  fixture for examples and tests, not a converged posterior.
+- Citation guidance: see `CITATION.cff` at the repo root for how to cite imuGAP.

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,6 +1,6 @@
 ## R CMD check results
 
-0 errors | 0 warnings | 2 notes
+0 errors | 0 warnings | 1 note
 
 This is a new submission.
 
@@ -11,11 +11,6 @@ This is a new submission.
   installed size above the usual threshold. The compiled models are required
   for the package's core functionality and cannot be reduced without removing
   it.
-
-* **S3 generic/method consistency** (`summary.imugap_predict`). [csmith701:
-  confirm wording. The `summary` method for `imugap_predict` objects takes
-  additional arguments beyond the `summary()` generic; tracked separately in
-  ACCIDDA/imuGAP#73.]
 
 (Stan model compilation also makes installation and any sampler-exercising
 examples slow; such examples are wrapped in `\dontrun{}` to keep check runtime
@@ -38,13 +33,11 @@ None on CRAN currently. The package is a dependency of the GitHub-only project
 
 ## Notes for reviewer
 
-[csmith701 to set the reviewer-facing voice; draft below per @pearsonca on #31.]
-
 First submission. Points that may be useful to the reviewer:
 
 - imuGAP wraps Stan models built with `rstantools` and follows the standard
   rstan package layout (`src/Makevars`, `src/stanExports_*`, `inst/stan/`).
-- Bundled example datasets (`locations_sim`, `observations_sim`,
-  `populations_sim`, `fit_sim`) are simulated and small; `fit_sim` is a wiring
-  fixture for examples and tests, not a converged posterior.
+- Bundled example datasets (`fit_sim`, `latent_params_sim`, `locations_sim`,
+  `observations_sim`, `populations_sim`, `predict_sim`, `target_sim`) are
+  simulated and small.
 - Citation guidance: see `CITATION.cff` at the repo root for how to cite imuGAP.


### PR DESCRIPTION
Fills in the `cran-comments.md` placeholder template now that R CMD check is clean on `main` (#74 merged).

## What changed
- **R CMD check results:** real values instead of `[N]` placeholder — 0 errors, 0 warnings, 2 notes:
  - *New submission* (expected, first CRAN release).
  - *Installed package size* (the bundled compiled Stan models; unavoidable for an rstan package).
  - *S3 generic/method consistency* on `summary.imugap_predict` (tracked separately in #73).
- **Test environments:** noted the GitHub Actions matrix results.
- **Downstream deps / reviewer notes:** kept, lightly cleaned.

## Deliberately left as markers (per @pearsonca on #31: "draft please, then @csmith701 does detailed content")
- `[csmith701]` on the reviewer-facing voice and the exact S3-note wording.
- `[TODO before submission]` on win-builder + R-hub results (not run yet) and the local-dev environment line.

## Confirm before actual submission (not blocking this draft)
The note/warning counts should be re-confirmed against a clean CI run. The latest run is green, but `macos-latest (oldrel)` logged a `colorspace not available` install warning — verified to be a stale-cache artifact (the merged `fit_sim` carries no colorspace/ggplot2/lubridate reference; that runner just lacks colorspace installed). A fresh run should show `2 NOTEs` there too. Not a defect in the merged code, but worth a clean re-run before hitting submit.

Refs #31