### PR TITLE
Use \donttest instead of \dontrun in sampling and predict examples

### DIFF
--- a/R/imuGAP.R
+++ b/R/imuGAP.R
@@ -14,7 +14,7 @@
 #'   along with settings and dataset metadata.
 #'
 #' @examples
-#' \dontrun{
+#' \donttest{
 #' data("locations_sim"); data("observations_sim"); data("populations_sim")
 #' st_opts <- stan_options(chains = 2, iter = 500)
 #' sampling(

--- a/R/methods.R
+++ b/R/methods.R
@@ -23,7 +23,7 @@
 #'   draws and the canonical target dataset.
 #'
 #' @examples
-#' \dontrun{
+#' \donttest{
 #' # Load example fit object and target population
 #' data("fit_sim", package = "imuGAP")
 #' data("target_sim", package = "imuGAP")


### PR DESCRIPTION
Addresses the `\dontrun` -> `\donttest` item of #86.

CRAN asked that the examples for `predict.imugap_fit` and `sampling` use `\donttest` instead of `\dontrun`. The `man/*.Rd` files are generated from roxygen and are gitignored, so this change is made in the roxygen `@examples` blocks of the R source:

- `R/imuGAP.R`: the `@examples` block for `sampling()`
- `R/methods.R`: the `@examples` block for `predict.imugap_fit()`

Both files still parse with `Rscript -e 'parse("R/<file>.R")'`. No `\dontrun` occurrences were changed elsewhere.

Scope is limited to the `\dontrun` -> `\donttest` change. The remaining #86 items (tarball size, predict redesign, DESCRIPTION references) are handled separately, so this uses `Refs #86` rather than closing it.