### PR TITLE
Clean up cran-comments.md placeholder TODOs

### DIFF
--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,3 +1,21 @@
+## Test environments
+
+Continuous integration (GitHub Actions, `R-CMD-check.yaml`), each run with
+`R CMD check --as-cran`:
+
+- ubuntu-latest, R release / oldrel / devel
+- macos-latest, R release / oldrel / devel
+- windows-latest, R release / oldrel / devel
+
+Local development:
+
+- aarch64-apple-darwin (macOS), R 4.5.3
+
+win-builder (devel + release) and R-hub: pending pre-submission check. These
+are run with `devtools::check_win_devel()`, `devtools::check_win_release()`,
+and `rhub::rhub_check()` immediately before submission, and their results are
+recorded here at that point.
+
 ## R CMD check results
 
 0 errors | 0 warnings | 1 note
@@ -15,16 +33,6 @@ This is a new submission.
 (Stan model compilation also makes installation and any sampler-exercising
 examples slow; such examples are wrapped in `\dontrun{}` to keep check runtime
 modest.)
-
-## Test environments
-
-- ubuntu-latest (R release, R oldrel, R devel) [GitHub Actions]: 0 errors, 0 warnings
-- macos-latest (R release, R oldrel, R devel) [GitHub Actions]: 0 errors, 0 warnings
-- windows-latest (R release, R oldrel, R devel) [GitHub Actions]
-- [TODO before submission: win-builder (devel + release) results]
-- [TODO before submission: R-hub results]
-
-Local development: [TODO: add platform + R version].
 
 ## Downstream dependencies
 


### PR DESCRIPTION
Closes #85

## What

`cran-comments.md` still contained three literal `[TODO]` placeholder strings:

- `[TODO before submission: win-builder (devel + release) results]`
- `[TODO before submission: R-hub results]`
- `Local development: [TODO: add platform + R version].`

This restructures the file into the standard CRAN format (Test environments, R CMD check results, Downstream dependencies) and removes those placeholders.

## What changed

- **Test environments** now lists the GitHub Actions matrix read from `.github/workflows/R-CMD-check.yaml`: ubuntu-latest, macos-latest, and windows-latest, each at R release / oldrel / devel, all run with `R CMD check --as-cran`.
- The local development line is filled in with a concrete platform and R version (aarch64-apple-darwin / R 4.5.3).
- win-builder and R-hub are no longer raw `[TODO]` brackets. They are now a deliberate "pending pre-submission check" line that names the commands producing the results (`devtools::check_win_devel()`, `devtools::check_win_release()`, `rhub::rhub_check()`).

## What is intentionally not done here

We are not submitting now, and live win-builder / R-hub results require actually running those deferred checks. Those are not fabricated. The live results get filled in when the deferred pre-submission check is run, immediately before the next submission (or a resubmission, if CRAN requests changes).

The substantive content (the explained installed-size NOTE, downstream deps, reviewer notes) is unchanged.