### PR TITLE
pkgdown fine-tuning: author links, contributor sidebar, footer logo

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -3,13 +3,23 @@ template:
   light-switch: true
   bootstrap: 5
 
+authors:
+  sidebar:
+    roles: [aut, cre, ctb]
+  Carl Pearson:
+    href: https://github.com/pearsonca
+  Claire Perrin Smith:
+    href: https://github.com/csmith701
+  Weston Voglesonger:
+    href: https://github.com/WestonVoglesonger
+
 footer:
   structure:
-    left: [developed_by, accidda]
-    right: built_with
+    left: developed_by
+    right: [built_with, accidda]
   components:
     accidda: |
-      <br><a href="https://accidda.org/" class="accidda-footer-link"
+      <a href="https://accidda.org/" class="accidda-footer-link"
       aria-label="Part of the ACCIDDA project"><img
       src="https://raw.githubusercontent.com/ACCIDDA/ACCIDDA-Images/refs/heads/main/accidda/accidda-logo-small.png"
       alt="ACCIDDA" class="accidda-footer-logo accidda-footer-logo-light"


### PR DESCRIPTION
Closes #78

Fine-tunes the pkgdown configuration in `_pkgdown.yml`. Changes are config-only; no site build is included.

### Addressed
- [x] **Author names as links.** Added an `authors:` section with a `href:` per author pointing at their GitHub profile, for the handles that can be confidently mapped:
  - Carl Pearson -> https://github.com/pearsonca
  - Claire Perrin Smith -> https://github.com/csmith701
  - Weston Voglesonger -> https://github.com/WestonVoglesonger
- [x] **Show contributors in the sidebar.** Added `authors.sidebar.roles: [aut, cre, ctb]` so contributors (`ctb`) render in the authors sidebar alongside authors and the maintainer. By default pkgdown omits `ctb` from the sidebar.
- [x] **Move ACCIDDA logo to footer-right like the posit logo.** Moved the `accidda` component from the footer `left` slot (where it stacked under `developed_by`) to the `right` slot after `built_with`, so it sits at the bottom-right of the footer, mirroring the posit logo placement on https://pkgdown.r-lib.org/index.html. Dropped the leading `<br>` that was only needed for the old left-column stacking.

### Deferred / not done
- [ ] **Author profile pictures pulled from GitHub.** This was listed as a desire in the issue. pkgdown has no native support for fetching author avatars, so this is deferred rather than hacked in.
- [ ] **GitHub handles for three contributors not mapped.** Kelly Zhen, Joshua Chen, and Minjae Kung (all `ctb`) could not be confidently matched to a GitHub account from DESCRIPTION, the repo contributor list, or the git log, so they are left unlinked. They can be added to the `authors:` block with a `href:` once their handles are confirmed.

### Validation
`pkgdown::check_pkgdown()` reports no problems. Verified via `pkgdown::as_pkgdown()` that the three mapped names render as profile links, that `ctb` is included in the sidebar roles, and that the footer `right` slot now contains `[built_with, accidda]`. A full site build was intentionally not run.