### PR TITLE
Cite the Zenodo archive instead of the package itself (#84)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # imuGAP <img src="man/figures/logo.png" align="right" height="139" alt="imuGAP logo" />
 
-[![codecov](https://codecov.io/gh/ACCIDDA/imuGAP/branch/main/graph/badge.svg)](https://app.codecov.io/gh/ACCIDDA/imuGAP)
+[![codecov](https://codecov.io/gh/ACCIDDA/imuGAP/branch/main/graph/badge.svg)](https://app.codecov.io/gh/ACCIDDA/imuGAP) [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.20562250.svg)](https://doi.org/10.5281/zenodo.20562250)
 
 `{imuGAP}`, which stands for "Immunity: Geographic & Age-based Projection", provides a fitting and imputation / prediction tool for a process-based model of vaccination uptake.
 

--- a/inst/CITATION
+++ b/inst/CITATION
@@ -1,0 +1,13 @@
+citHeader("To cite imuGAP in publications, please use the Zenodo archive:")
+
+bibentry(
+  bibtype = "Manual",
+  title   = "imuGAP: Immunity: Geographic and Age-Based Projection",
+  author  = c(
+    person("Carl", "Pearson"),
+    person("Claire Perrin", "Smith")
+  ),
+  year    = "2026",
+  note    = "R package version 0.1.0",
+  doi     = "10.5281/zenodo.20562250"
+)


### PR DESCRIPTION
Closes #84.

- Adds `inst/CITATION` citing the imuGAP Zenodo archive via the **concept DOI** `10.5281/zenodo.20562250` (resolves to the latest version), so `citation("imuGAP")` and the pkgdown Citation page reference the archive rather than an auto-generated self-citation.
- Adds the Zenodo DOI badge to the README.

Authors in the citation match the two `aut` authors on the Zenodo record (Pearson, Smith). Validated locally with `utils::readCitationFile()`; renders cleanly and the existing `R CMD check` will also parse it.

Note for later: the badge uses the concept DOI so it auto-tracks releases, but the `note = "R package version 0.1.0"` / year in `inst/CITATION` should be bumped at the next release.
