### PR TITLE
Minor updates to vignette in response to beta testing feedback

### DIFF
--- a/vignettes/imuGAP.Rmd
+++ b/vignettes/imuGAP.Rmd
@@ -29,7 +29,9 @@ if (!pkgs_available) {
   knitr::opts_chunk$set(eval = FALSE)
   message("Some suggested packages are missing. Vignette code will not be executed.")
 } else {
-  suppressPackageStartupMessages(
+  # Assign the result so the chunk does not auto-print the logical vector
+  # sapply() returns (the setup block should render no output).
+  chk <- suppressPackageStartupMessages(
     sapply(required_pkgs, require, character.only = TRUE)
   )
 }

--- a/vignettes/imuGAP.Rmd
+++ b/vignettes/imuGAP.Rmd
@@ -14,7 +14,7 @@ knitr::opts_chunk$set(
 )
 ```
 
-```{r setup, echo = FALSE, message = FALSE}
+```{r setup, echo = FALSE, message = FALSE, warning=FALSE}
 # List all suggested packages needed for this vignette
 required_pkgs <- c(
   "imuGAP", "data.table", "bayesplot", "ggplot2",
@@ -37,9 +37,13 @@ if (!pkgs_available) {
 
 # Introduction
 
-The name `imuGAP` stands for "Immunity: Geographic & Age-based Projection". The package provides a [stan](https://mc-stan.org/)-based model for estimating vaccination coverage by location, cohort, and age for childhood infectious diseases, such as measles.
+The name `imuGAP` stands for "Immunity: Geographic & Age-based Projection". This package allows the user to synthesize across multiple data sources to make predictions of vaccination coverage for user-defined populations of interest. For example, one could use the package to:
 
-The core model represents a target population as having a life-long propensity for vaccination; some proportion, $\phi$, of that population is unlikely to vaccinate and the complementary proportion, $1 - \phi$, is likely to vaccinate. That population then experiences a vaccination rate, $\lambda$, over the model time eras, according to the vaccination eligibility schedule, $\nu$. These core parameters can vary over time and location, in a user-specifiable way.
+1. Estimate current vaccination coverage by location across different age groups
+2. Estimate coverage (or uptake) for a given birth cohort (e.g. people born in 1990) across their life course (i.e. at each age from birth to current age)
+3. Fill in gaps in observed coverage data (e.g. a school that doesn't report vaccination coverage in a certain year)
+
+More specifically, the package provides a [stan](https://mc-stan.org/)-based model for estimating vaccination coverage by location, cohort, and age for childhood infectious diseases, such as measles. The core model represents a target population as having a life-long propensity for vaccination; some proportion, $\phi$, of that population is unlikely to vaccinate and the complementary proportion, $1 - \phi$, is likely to vaccinate. That population then experiences a vaccination rate, $\lambda$, over the model time eras, according to the vaccination eligibility schedule, $\nu$. These core parameters can vary over time and location, in a user-specifiable way.
 
 Focusing just on the core model element, imagine a particular population location $i$ and cohort $a$ (where $a$ denotes the start of the time period when that group was born). If that cohort is now age $t$, and the vaccine schedule for the first dose is $\nu(t)$, the expected fraction of that group to have at least one dose is then:
 
@@ -138,7 +142,7 @@ See the `canonicalize_*` function documentation for more complete validation req
 
 Using the prepared input datasets, we can fit the Bayesian model using `sampling()`. The options for the sampler can be configured using `stan_options()`.
 
-Because compiling the Stan model and running the MCMC chain can take some time, we set `eval = FALSE` below. In practice, you could run:
+Because compiling the Stan model and running the MCMC chain can take some time, we show the code below without executing it.
 
 ```{r sampling-code, eval = FALSE}
 fit_sim <- sampling(
@@ -178,7 +182,7 @@ bayesplot::mcmc_trace(fit_sim$stanfit,
 
 ## 3. Defining a Target for Predictions
 
-To predict vaccine coverage for a target population (which can include locations or cohorts without direct observations, as long as they exist in the locations hierarchy), we first define a target grid using `create_target()`. 
+To predict vaccine coverage for a target population (which can include locations or cohorts without direct observations, as long as they exist in the locations hierarchy), we first define a target grid using `create_target()`. Note that predictions can only be made for birth cohorts and locations that have at least some observations included in the estimation run. In other words, the model cannot predict coverage for future birth cohorts or unobserved locations. 
 
 For example, we can generate a "snapshot" prediction target for all locations, including the State and County levels, across ages 1 to 18:
 


### PR DESCRIPTION
Some minor updates to vignette in response to feedback from beta testing. Specifically:

- In the walkthrough, for “2. Fitting the Model” the initial explanation for why we were not running the model was confusing, particularly the part about setting “eval = FALSE” because that doesn’t show up in the code snippet. The way it was explained in “4. Predicting Coverage” was much clearer: “we show the code below without executing it […] instead, we load the pre-computed prediction results.”
- Depending on the target user of this package, it may be beneficial to provide a more plain-language explanation at the beginning of the Introduction section under “Getting Started.” What is the core functionality of the package as it would be explained to someone working, for instance, in the VPD section of a health department?
- It would be useful to be more explicit about what “estimating vaccination coverage” means in this context. Does the package predict the future level of vaccination coverage based on the currently available data or estimate the vaccine coverage at the current point in time, based on incomplete data, or both? From a public health user perspective, I’d be uncertain about how to interpret the output as is.