### PR TITLE
cran-comments: drop R-hub, keep win-builder

### DIFF
--- a/cran-comments.md
+++ b/cran-comments.md
@@ -25,10 +25,8 @@ Local development:
 
 - aarch64-apple-darwin (macOS), R 4.5.3
 
-win-builder (devel + release) and R-hub: pending pre-submission check. These
-are run with `devtools::check_win_devel()`, `devtools::check_win_release()`,
-and `rhub::rhub_check()` immediately before submission, and their results are
-recorded here at that point.
+win-builder: R-devel and R-release, submitted before this release. Results are
+recorded here once returned.
 
 ## R CMD check results
 


### PR DESCRIPTION
Small accuracy fix to `cran-comments.md` before the resubmission.

We are **not** using R-hub for this release, so the cran-comments shouldn't claim it. Reasons:
- R-hub v1 (the submit-a-tarball service) was decommissioned; v2 is GitHub-Actions-based and would mean committing a new workflow to the repo.
- The existing `R CMD check --as-cran` matrix (ubuntu/macOS/windows x release/oldrel/devel) already covers the multi-platform checks R-hub would add.
- R-hub wasn't actually run for the initial submission either (it was a `[TODO]` placeholder).

**win-builder R-devel and R-release have been submitted** (the pre-submission check the cran-comments references); results go to the maintainer email and get pasted into the results section when they return.
