### PR TITLE
Point install quickstart to CRAN (#102)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,18 @@
 # imuGAP <img src="man/figures/logo.png" align="right" height="139" alt="imuGAP logo" />
 
-[![codecov](https://codecov.io/gh/ACCIDDA/imuGAP/branch/main/graph/badge.svg)](https://app.codecov.io/gh/ACCIDDA/imuGAP) [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.20562250.svg)](https://doi.org/10.5281/zenodo.20562250)
+[![CRAN status](https://www.r-pkg.org/badges/version/imuGAP)](https://CRAN.R-project.org/package=imuGAP) [![codecov](https://codecov.io/gh/ACCIDDA/imuGAP/branch/main/graph/badge.svg)](https://app.codecov.io/gh/ACCIDDA/imuGAP) [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.20562250.svg)](https://doi.org/10.5281/zenodo.20562250)
 
 `{imuGAP}`, which stands for "Immunity: Geographic & Age-based Projection", provides a fitting and imputation / prediction tool for a process-based model of vaccination uptake.
 
 ## Installation
+
+Install the released version from CRAN:
+
+```r
+install.packages("imuGAP")
+```
+
+Or install the development version from GitHub:
 
 ```r
 remotes::install_github("ACCIDDA/imuGAP")


### PR DESCRIPTION
Closes #102.

imuGAP 0.1.0 is now on CRAN, so the README quickstart should lead with the released install and relegate the GitHub install to the development version.

## Changes
- **Installation**: `install.packages("imuGAP")` (CRAN) shown first; `remotes::install_github("ACCIDDA/imuGAP")` kept as the development/latest version.
- Added a **CRAN status badge**.

Only `README.md` carries install guidance (the vignette and pkgdown config have none), so this is the full scope.