### PR TITLE
Route predict/extract through portable backend accessors

### DIFF
--- a/R/backends.R
+++ b/R/backends.R
@@ -348,3 +348,99 @@ fit_cmdstanr <- function(model_name, args, drop_pars = NULL) {
   do.call(mod$sample, args)
   # nocov end
 }
+
+# --- Fit consumption ---------------------------------------------------------
+# The fit_BACKEND() functions above produce a backend-native fit object (an
+# rstan stanfit or a cmdstanr CmdStanMCMC). Downstream code (prediction,
+# parameter extraction) needs to read draws and run generated quantities off
+# that object without knowing which backend produced it. These accessors are
+# that portable seam: dispatch on the fit object's backend, so callers stay
+# backend-agnostic. Only the rstan paths are implemented today; the cmdstanr
+# paths are stubs pending backend support downstream (they require the CmdStan
+# toolchain, so they cannot run on CI/CRAN regardless).
+
+#' Identify the backend that produced a fit object
+#'
+#' @param raw_fit a backend-native fit object (an rstan `stanfit` or a cmdstanr
+#'   `CmdStanMCMC`).
+#' @returns `"rstan"` or `"cmdstanr"`.
+#' @keywords internal
+fit_backend <- function(raw_fit) {
+  if (inherits(raw_fit, "stanfit")) {
+    "rstan"
+  } else if (inherits(raw_fit, "CmdStanMCMC")) {
+    "cmdstanr"
+  } else {
+    stop(
+      "unrecognized fit object; expected an rstan 'stanfit' or a cmdstanr ",
+      "'CmdStanMCMC'.",
+      call. = FALSE
+    )
+  }
+}
+
+#' Posterior draws of a fit as an iterations x chains x parameters array
+#'
+#' @param raw_fit a backend-native fit object.
+#' @returns a 3-D array, dimensions iterations x chains x parameters.
+#' @keywords internal
+backend_draws_array <- function(raw_fit) {
+  switch(
+    fit_backend(raw_fit),
+    rstan = as.array(raw_fit),
+    # nocov start: needs the cmdstanr backend + CmdStan toolchain.
+    cmdstanr = stop(
+      "reading draws from a cmdstanr fit is not yet implemented.",
+      call. = FALSE
+    )
+    # nocov end
+  )
+}
+
+#' Extract named parameters from a fit as a list of arrays
+#'
+#' Matches the shape returned by [rstan::extract()].
+#'
+#' @param raw_fit a backend-native fit object.
+#' @param pars character vector of parameter names to extract.
+#' @param ... forwarded to the backend's extractor.
+#' @returns a named list of draw arrays, one per parameter.
+#' @importFrom rstan extract
+#' @keywords internal
+backend_extract <- function(raw_fit, pars, ...) {
+  switch(
+    fit_backend(raw_fit),
+    rstan = rstan::extract(raw_fit, pars = pars, ...),
+    # nocov start: needs the cmdstanr backend + CmdStan toolchain.
+    cmdstanr = stop(
+      "extracting parameters from a cmdstanr fit is not yet implemented.",
+      call. = FALSE
+    )
+    # nocov end
+  )
+}
+
+#' Run generated quantities against a fit and return a parameter matrix
+#'
+#' @param raw_fit a backend-native fit object.
+#' @param data the Stan data list for the generated-quantities run.
+#' @param draws_mat a draws matrix (rows = draws, columns = parameters).
+#' @param pars name of the generated parameter to return.
+#' @returns a matrix of the requested generated parameter (rows = draws).
+#' @importFrom rstan gqs
+#' @keywords internal
+backend_generate_quantities <- function(raw_fit, data, draws_mat, pars) {
+  switch(
+    fit_backend(raw_fit),
+    rstan = as.matrix(
+      rstan::gqs(raw_fit@stanmodel, data = data, draws = draws_mat),
+      pars = pars
+    ),
+    # nocov start: needs the cmdstanr backend + CmdStan toolchain.
+    cmdstanr = stop(
+      "generated quantities from a cmdstanr fit are not yet implemented.",
+      call. = FALSE
+    )
+    # nocov end
+  )
+}

--- a/R/imuGAP.R
+++ b/R/imuGAP.R
@@ -335,8 +335,9 @@ extract_imugap <- function(fit, pars = c("beta_bs"), ...) {
   if (!inherits(fit, "imugap_fit")) {
     stop("fit must be an object of class 'imugap_fit'", call. = FALSE)
   }
-  # rstan::extract() needs a stanfit; cmdstanr fits expose draws differently
-  # (see #100), so fail clearly rather than erroring deep inside rstan.
+  # Extraction goes through the backend accessor, which only implements the
+  # rstan path today; cmdstanr fits expose draws differently, so fail clearly
+  # here rather than deep inside the accessor.
   if (!inherits(fit$stanfit, "stanfit")) {
     stop(
       "extract_imugap() currently supports only the rstan backend. Refit with ",
@@ -344,5 +345,5 @@ extract_imugap <- function(fit, pars = c("beta_bs"), ...) {
       call. = FALSE
     )
   }
-  rstan::extract(fit$stanfit, pars = pars, ...)
+  backend_extract(fit$stanfit, pars = pars, ...)
 }

--- a/R/methods.R
+++ b/R/methods.R
@@ -46,7 +46,6 @@
 #'
 #' @export
 #' @importFrom data.table as.data.table copy data.table
-#' @importFrom rstan gqs extract
 predict.imugap_fit <- function(
   object,
   target,
@@ -59,9 +58,10 @@ predict.imugap_fit <- function(
   }
 
   raw_fit <- fit$stanfit
-  # predict() runs generated quantities via rstan::gqs(), which needs a stanfit.
-  # cmdstanr fits return a CmdStanMCMC; their generated-quantities support is a
-  # separate piece of work (tracked in #100), so fail clearly for now.
+  # predict() runs generated quantities through the backend accessors, which
+  # only implement the rstan path today. cmdstanr fits return a CmdStanMCMC;
+  # their generated-quantities support is a separate piece of work, so fail
+  # clearly here rather than deep inside the accessor.
   if (!inherits(raw_fit, "stanfit")) {
     stop(
       "predict() currently supports only the rstan backend. Refit with ",
@@ -72,7 +72,7 @@ predict.imugap_fit <- function(
   }
 
   # Posterior draws as a 3D array: iterations x chains x parameters.
-  draws_array <- as.array(raw_fit)
+  draws_array <- backend_draws_array(raw_fit)
   n_iter <- dim(draws_array)[1]
   n_chains <- dim(draws_array)[2]
   n_avail <- n_iter * n_chains
@@ -161,16 +161,11 @@ predict.imugap_fit <- function(
   # Flatten to the 2D draws matrix gqs expects (rows = draws, cols = params).
   draws_mat <- apply(draws_sub, 3L, c)
 
-  # Run gqs to generate predictions
-  gqs_res <- rstan::gqs(
-    raw_fit@stanmodel,
-    data = dat_stan,
-    draws = draws_mat
+  # Predicted coverage via the backend's generated-quantities run, reshaped to
+  # iterations x chains x targets so the per-chain structure is preserved.
+  p_obs_mat <- backend_generate_quantities(
+    raw_fit, dat_stan, draws_mat, "p_obs"
   )
-
-  # Predicted coverage, reshaped to iterations x chains x targets so the
-  # per-chain structure is preserved.
-  p_obs_mat <- as.matrix(gqs_res, pars = "p_obs")
   p_obs_draws <- array(p_obs_mat, dim = c(n_keep, n_chains, ncol(p_obs_mat)))
 
   structure(

--- a/tests/testthat/test-backends.R
+++ b/tests/testthat/test-backends.R
@@ -198,3 +198,35 @@ test_that("fit_rstan forwards drop_pars to rstan::sampling", {
     .package = "rstan"
   )
 })
+
+# --- Fit-consumption accessors (the portable predict/extract seam) -----------
+# The rstan paths are exercised end-to-end by the predict()/extract_imugap()
+# tests; here we cover the backend dispatch and the not-yet-implemented cmdstanr
+# stubs directly, with fake fit objects, so no Stan toolchain is needed.
+
+test_that("fit_backend identifies the backend and rejects unknown fits", {
+  expect_identical(fit_backend(structure(list(), class = "stanfit")), "rstan")
+  expect_identical(
+    fit_backend(structure(list(), class = "CmdStanMCMC")), "cmdstanr"
+  )
+  expect_error(fit_backend(list()), "unrecognized fit object")
+})
+
+test_that("backend_extract dispatches to rstan::extract for an rstan fit", {
+  fake_rstan <- structure(list(), class = "stanfit")
+  with_mocked_bindings(
+    expect_identical(backend_extract(fake_rstan, "beta_bs"), "mocked_extract"),
+    extract = function(object, pars, ...) "mocked_extract",
+    .package = "rstan"
+  )
+})
+
+test_that("the cmdstanr accessors error until cmdstanr support lands", {
+  cmd <- structure(list(), class = "CmdStanMCMC")
+  expect_error(backend_draws_array(cmd), "not yet implemented")
+  expect_error(backend_extract(cmd, "beta_bs"), "not yet implemented")
+  expect_error(
+    backend_generate_quantities(cmd, list(), matrix(0), "p_obs"),
+    "not yet implemented"
+  )
+})


### PR DESCRIPTION
First step on #112, addressing @pearsonca's note there: *"figure out using the backends portably in predict / extract."*

`predict.imugap_fit` and `extract_imugap` previously called rstan directly (`as.array`, `rstan::gqs(fit@stanmodel)`, `rstan::extract`) and hard-rejected cmdstanr fits. This moves those fit-consumption operations behind portable accessors in `backends.R`:

- `fit_backend(raw_fit)` -> `"rstan"`/`"cmdstanr"`
- `backend_draws_array(raw_fit)` -> iterations x chains x parameters array
- `backend_extract(raw_fit, pars, ...)` -> list of draw arrays
- `backend_generate_quantities(raw_fit, data, draws_mat, pars)` -> generated-parameter matrix

Only the rstan paths are implemented; the cmdstanr paths are `# nocov` stubs (they need the CmdStan toolchain, absent on CI/CRAN). **Behavior is unchanged** - predict/extract still guard to the rstan backend today; this just establishes the seam so a vendored `backends.R` carries the operations, and cmdstanr support later drops into `backends.R` alone.

The other parts of #112 (hosting `backends.R` in a standalone repo, `use_standalone` + CI sync) are separate and need the repo-location decision.

Verified locally: 0 lints; the backends/predict/extract tests pass (128).