### PR TITLE
docs: document the flexstanr sync + cmdstanr/Remotes automation in CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,19 +76,31 @@ R CMD build . && R CMD check imuGAP_*.tar.gz
 vendored from [ACCIDDA/flexstanr](https://github.com/ACCIDDA/flexstanr) — the
 single source of truth for the portable backend layer shared across imuGAP,
 hestia, and SeverityEstimate (see #112). Its header says *"do not edit by
-hand,"* and it is excluded from linting.
+hand."*
 
-- To change backend behavior, edit **flexstanr**, then re-sync here:
+- To change backend behavior, edit **flexstanr**, then re-sync here. The
+  preferred way is the justfile recipe:
+  ```sh
+  just update-standalones
+  ```
+  It re-runs `use_standalone` for each vendored source and restores `DESCRIPTION`
+  afterwards. The manual equivalent is:
   ```r
   usethis::use_standalone("ACCIDDA/flexstanr", "backends")
   ```
-  That call also rewrites `DESCRIPTION` (it strips version pins, e.g.
-  `rstan (>= 2.18.1)` → `rstan`) — **revert that DESCRIPTION change**; the
-  re-sync should only touch `R/import-standalone-backends.R`.
+  but note that call also rewrites `DESCRIPTION` — it strips version pins, e.g.
+  `rstan (>= 2.18.1)` → `rstan`
+  ([usethis#2198](https://github.com/r-lib/usethis/issues/2198)) — so you must
+  **revert that DESCRIPTION change** by hand; the re-sync should only touch
+  `R/import-standalone-backends.R`. The recipe does that revert for you.
+- The vendored header's `# repo: ACCIDDA/flexstanr` line parses as R, so
+  `commented_code_linter` is disabled globally in `.lintr` (rather than excluding
+  the file); the vendored file is otherwise linted like any other.
 - `use_standalone` is a one-shot copy, so the vendored file can fall behind
-  upstream. The **`backends-sync`** workflow (weekly, read-only) fails when the
-  vendored copy has drifted from flexstanr — a failing scheduled run is your cue
-  to re-sync.
+  upstream. The **`backends-sync`** workflow (weekly) discovers every vendored
+  standalone file, reads each one's source from its `# Source:` header, compares
+  against upstream, and — if anything has drifted — opens a pull request with the
+  refreshed copies. Review and merge that PR to re-sync.
 
 ## Dependencies: cmdstanr, `Remotes`, and the pak gotcha
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -70,6 +70,41 @@ R CMD build . && R CMD check imuGAP_*.tar.gz
   top-level `.stan` files — prefer toggling includes over duplicating
   whole model files.
 
+## The Stan backend is vendored from flexstanr
+
+`R/import-standalone-backends.R` is **not edited here**. It is a standalone file
+vendored from [ACCIDDA/flexstanr](https://github.com/ACCIDDA/flexstanr) — the
+single source of truth for the portable backend layer shared across imuGAP,
+hestia, and SeverityEstimate (see #112). Its header says *"do not edit by
+hand,"* and it is excluded from linting.
+
+- To change backend behavior, edit **flexstanr**, then re-sync here:
+  ```r
+  usethis::use_standalone("ACCIDDA/flexstanr", "backends")
+  ```
+  That call also rewrites `DESCRIPTION` (it strips version pins, e.g.
+  `rstan (>= 2.18.1)` → `rstan`) — **revert that DESCRIPTION change**; the
+  re-sync should only touch `R/import-standalone-backends.R`.
+- `use_standalone` is a one-shot copy, so the vendored file can fall behind
+  upstream. The **`backends-sync`** workflow (weekly, read-only) fails when the
+  vendored copy has drifted from flexstanr — a failing scheduled run is your cue
+  to re-sync.
+
+## Dependencies: cmdstanr, `Remotes`, and the pak gotcha
+
+cmdstanr is an optional, non-CRAN `Suggests`. It is resolved in CI via
+**`Remotes: stan-dev/cmdstanr`** in `DESCRIPTION`: pak (used by `r-lib/actions`)
+reads `Remotes` but **not** `Additional_repositories`
+([r-lib/pak#424](https://github.com/r-lib/pak/issues/424)). The
+`Additional_repositories` entry is kept only for base `install.packages` and
+`R CMD check --as-cran`.
+
+**Do not** add the stan-dev r-universe as a repository (e.g. an
+`extra-repositories` in a workflow): pak would then prefer its **dev** builds of
+the whole Stan stack (StanHeaders/rstan), which fail to compile against CRAN's
+RcppEigen and break every job. `Remotes` pins *only* cmdstanr and keeps the rest
+of the Stan stack on CRAN. (This one has bitten us — see #101.)
+
 ## What Happens When You Open a PR
 
 Every pull request triggers two GitHub Actions workflows:

--- a/justfile
+++ b/justfile
@@ -78,6 +78,19 @@ install: renv-install
 remove:
 	R CMD REMOVE {{ PKG }}
 
+[doc('Re-vendor standalone files from their sources, reverting the DESCRIPTION churn use_standalone introduces (usethis#2198)')]
+update-standalones:
+	#!/usr/bin/env Rscript
+	if (!require(usethis)) stop("missing 'usethis'")
+	# use_standalone() also rewrites DESCRIPTION (it strips version pins and
+	# adds imports). That churn is unwanted here (usethis#2198), so snapshot
+	# DESCRIPTION and restore it afterwards -- the vendored
+	# R/import-standalone-*.R file is the only change we keep. Add one
+	# use_standalone() call per source below.
+	desc <- readLines("DESCRIPTION")
+	usethis::use_standalone("ACCIDDA/flexstanr", "backends")
+	writeLines(desc, "DESCRIPTION")
+
 [group('data')]
 [doc('Regenerate all package data (inputs + fitted artifacts; inputs need nc_measles)')]
 data: data-inputs data-fit


### PR DESCRIPTION
Per @pearsonca's aside on #117 ("we're stacking up convenient-but-complex automation — do we have a CONTRIBUTING.md?"): we do, but it predated the newer machinery. This adds two sections:

- **The Stan backend is vendored from flexstanr** — do-not-edit `R/import-standalone-backends.R`, how to re-sync via `use_standalone` (and revert its DESCRIPTION churn), and the `backends-sync` drift check.
- **cmdstanr, `Remotes`, and the pak gotcha** — pak reads `Remotes` not `Additional_repositories` (r-lib/pak#424); do not add the stan-dev r-universe as a repo (dev StanHeaders breaks the build). The #101 lesson, written down.

The flexstanr section describes files/workflow landing in #117, so this reads cleanest merged after (or alongside) it.