### PR TITLE
CI: build artifacts once and share across the check matrix (lever 2)

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -6,7 +6,50 @@ on:
   pull_request:
 
 jobs:
+  # Generate the gitignored, platform-independent build artifacts ONCE, then
+  # share them with every matrix leg. fit_data.R (the fitted datasets) and
+  # roxygenise (man/, NAMESPACE, R/globals.R) are the same regardless of the
+  # check platform, but each of the 9 legs was regenerating them -- fit_data.R
+  # alone is ~2 min on Linux and ~5.5 min on Windows per leg. Running it once
+  # on Linux and downloading the result removes that redundant work.
+  #
+  # Sharing the Linux-built fitted data to the macOS/Windows legs is safe: the
+  # CRAN submission tarball is built on Linux with exactly these .rda files and
+  # is checked by CRAN across all platforms, so their cross-platform loading is
+  # already validated.
+  prep:
+    runs-on: ubuntu-latest
+
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+      R_KEEP_PKG_SOURCE: yes
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Setup imuGAP CI environment
+        uses: ./.github/actions/setup-imugap
+        with:
+          extra-packages: any::roxygen2, any::roxyglobals, any::pkgload
+          needs: check
+
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: prep-build-artifacts
+          if-no-files-found: error
+          retention-days: 1
+          path: |
+            data/fit_sim.rda
+            data/target_sim.rda
+            data/predict_sim.rda
+            man
+            NAMESPACE
+            R/globals.R
+
   R-CMD-check:
+    needs: prep
     runs-on: ${{ matrix.config.os }}
 
     name: ${{ matrix.config.os }} (${{ matrix.config.r }})
@@ -35,12 +78,28 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
 
+      # Restore the fitted data + man/ + NAMESPACE + R/globals.R produced by the
+      # prep job, so this leg does not regenerate them.
+      - name: Download build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: prep-build-artifacts
+          path: .
+
+      # Build steps are toggled off: the artifacts above already provide the
+      # NAMESPACE, docs, and fitted data, so this leg only needs R + the check
+      # dependencies before running R CMD check (which builds/compiles the
+      # tarball itself, independently of the fitted-data step).
       - name: Setup imuGAP CI environment
         uses: ./.github/actions/setup-imugap
         with:
           r-version: ${{ matrix.config.r }}
           extra-packages: any::rcmdcheck, any::roxygen2, any::roxyglobals, any::pkgload
           needs: check
+          bootstrap-namespace: 'false'
+          cache-stan: 'false'
+          generate-data: 'false'
+          generate-docs: 'false'
 
       - name: Check package
         uses: r-lib/actions/check-r-package@v2

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -109,12 +109,23 @@ jobs:
 
   check-result:
     if: always()
-    needs: [R-CMD-check]
+    needs: [prep, R-CMD-check]
     runs-on: ubuntu-latest
     steps:
-      - name: Verify all required checks passed
+      - name: Verify prep and all required checks passed
         run: |
-          if [ "${{ needs.R-CMD-check.result }}" = "failure" ]; then
-            echo "One or more required checks failed"
+          # Fail on anything that is not a clean success (failure, skipped,
+          # cancelled). In particular, if `prep` fails the matrix legs are
+          # SKIPPED rather than failed, so checking only for "failure" would let
+          # a prep failure slip through as a green required check.
+          # (devel legs are continue-on-error, so a devel failure is reported as
+          # success in the matrix result and is tolerated as before.)
+          if [ "${{ needs.prep.result }}" != "success" ]; then
+            echo "prep job did not succeed (result: ${{ needs.prep.result }})"
             exit 1
           fi
+          if [ "${{ needs.R-CMD-check.result }}" != "success" ]; then
+            echo "R-CMD-check did not succeed (result: ${{ needs.R-CMD-check.result }})"
+            exit 1
+          fi
+          echo "prep and R-CMD-check both succeeded."


### PR DESCRIPTION
Implements **lever 2** of #124. **Stacked on #125** (the composite-action PR) — base branch is `ci/centralize-setup`, so review/merge #125 first; this diff shows only the lever-2 change.

## What it does
The R-CMD-check matrix regenerated the same platform-independent artifacts on every one of its 9 legs. Measured on #125's cold run: `fit_data.R` is **~2 min/leg on Linux and ~5.5 min/leg on Windows**, plus roxygenise for `man/` + `NAMESPACE` + `R/globals.R`.

This adds a `prep` job that builds them **once on Linux** and uploads them; each matrix leg downloads them and runs the composite setup with the build steps toggled off (`bootstrap-namespace` / `cache-stan` / `generate-data` / `generate-docs` = false), then `R CMD check`.

## Why Check isn't slowed down
`R CMD check` builds and compiles the tarball itself, independently of `fit_data.R` — the check's own compile was never reusing fit_data's. So removing fit_data from a leg is pure savings; the Check step is unchanged.

## Why cross-platform sharing is safe
The `cran-submission.yaml` tarball is built on Linux with exactly these `.rda` files, and CRAN checks that one tarball across Windows/macOS/Linux. imuGAP already passed CRAN, so a Linux-built `fit_sim.rda` loading on other platforms is already validated.

## Expected effect
- **Cost:** `fit_data.R` runs 1× (prep) instead of 11× — large runner-minute saving.
- **Wall-clock (cold):** ~2 min off the critical path — prep on cheap Linux replaces Windows's 5.5-min per-leg fit.
- **Wall-clock (warm, hot Stan cache):** roughly neutral — fit_data is cheap when the compile is cached, so the prep serialization ~cancels the per-leg saving.

## Scope
R-CMD-check only. pkgdown/coverage run `fit_data.R` once, so a prep job there would only add serialization, not remove it.

## Verification
YAML validated; job graph is `prep → R-CMD-check (matrix) → check-result`. The real test is this PR's CI — in particular whether the macOS/Windows legs pass while loading the Linux-built fitted data (expected to, per the CRAN argument above). I'll report the result.
